### PR TITLE
fix(analyze): fix the npm run analyze

### DIFF
--- a/packages/vendor/lib/WebpackExportForemanVendorPlugin.js
+++ b/packages/vendor/lib/WebpackExportForemanVendorPlugin.js
@@ -3,8 +3,6 @@ const { default: InjectPlugin } = require('webpack-inject-plugin');
 function customLoader({ modules }) {
   const results = modules.map(module => module.createModuleExport()).join(' ');
 
-  console.log('results', results);
-
   return () => results;
 }
 

--- a/packages/vendor/lib/createVendorEntry.js
+++ b/packages/vendor/lib/createVendorEntry.js
@@ -3,8 +3,6 @@ const { modules } = require('@theforeman/vendor-core');
 const createVendorEntry = () => {
   const entry = ['./scss/vendor.scss', ...modules.map(module => module.path)];
 
-  console.log('entry', entry);
-
   return entry;
 };
 

--- a/packages/vendor/scripts/webpack-analyze.sh
+++ b/packages/vendor/scripts/webpack-analyze.sh
@@ -4,7 +4,7 @@ NODE_ENV=production
 PROJECT_PATH=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 PROJECT_PATH="${PROJECT_PATH}/.."
 PATH="$PROJECT_PATH/node_modules/.bin:$PATH"
-WEBPACK="webpack --config $PROJECT_PATH/webpack.config.js"
+WEBPACK="node --max_old_space_size=8192 ./node_modules/.bin/webpack --mode=production --config $PROJECT_PATH/webpack.config.js"
 REPORT_DIR="$PROJECT_PATH/dist-analyze"
 REPORT="${REPORT_DIR}/report.html"
 


### PR DESCRIPTION
Fix the issue causing the `npm run analyze` to fail.

## PR Type

* [x] Bugfix
* [ ] Feature
* [ ] Code style update (whitespace, formatting, missing semicolons, etc.)
* [ ] Refactoring (no functional changes, no api changes)
* [ ] Build related changes
* [ ] CI related changes
* [ ] Documentation content changes
* [ ] Other… Please describe:

## Description

It failed from 2 reasons:
1. It uses stdout to write the `stats.json` file so `console.log` statements corrupt the `stats.json`
2. The webpack build failed because it didn't have enough memory

## Does this PR introduce a breaking change?

* [ ] Yes
* [x] No

## Checklist:

<!--- Put an `x` in all the boxes that apply. -->

<!--- If you‘re unsure about any of these, don‘t hesitate to ask. We‘re here to help! -->

* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [x] I have read the [`contributing.md`](https://github.com/theforeman/foreman-js/blob/master/contributing.md).
