### PR TITLE
Fixes #4 - Build development and production

### DIFF
--- a/packages/vendor-core/package-lock.json
+++ b/packages/vendor-core/package-lock.json
@@ -1570,13 +1570,10 @@
 			"version": "0.5.6",
 			"resolved": "https://registry.npmjs.org/gridster/-/gridster-0.5.6.tgz",
 			"integrity": "sha1-QCRxOqvVWQk6cum3E/HkH5ve128=",
-			"requires": {
-				"jquery": "git+https://github.com/jquery/jquery.git#f852e631ba85af7da4ad7594785e122504e7b233"
-			},
 			"dependencies": {
 				"jquery": {
 					"version": "git+https://github.com/jquery/jquery.git#f852e631ba85af7da4ad7594785e122504e7b233",
-					"from": "git+https://github.com/jquery/jquery.git#2.0.3"
+					"from": "git+https://github.com/jquery/jquery.git#f852e631ba85af7da4ad7594785e122504e7b233"
 				}
 			}
 		},

--- a/packages/vendor/lib/Manifest.js
+++ b/packages/vendor/lib/Manifest.js
@@ -1,0 +1,39 @@
+/* eslint-disable global-require, import/no-dynamic-require */
+const path = require('path');
+
+const manifestFiles = {
+  production: path.join(__dirname, '../dist/manifest.production.json'),
+  development: path.join(__dirname, '../dist/manifest.development.json'),
+};
+
+class Manifest {
+  get data() {
+    if (!this._data) {
+      this._loadManifest();
+    }
+
+    return this._data;
+  }
+
+  get files() {
+    return []
+      .concat(...Object.values(this.data))
+      .map(file => path.join(__dirname, '../dist', file));
+  }
+
+  constructor(mode = 'production') {
+    this.mode = mode;
+  }
+
+  _loadManifest() {
+    const filename = manifestFiles[this.mode];
+
+    try {
+      this._data = require(filename);
+    } catch (error) {
+      throw new Error(`Unable to load manifest file: ${filename}`);
+    }
+  }
+}
+
+module.exports = Manifest;

--- a/packages/vendor/package.json
+++ b/packages/vendor/package.json
@@ -17,7 +17,10 @@
   "sideEffects": true,
   "scripts": {
     "prebuild": "rimraf dist",
-    "build": "node --max_old_space_size=8192 ./node_modules/.bin/webpack --config webpack.config.js",
+    "build": "npm run build:dev && npm run build:prod",
+    "build:base": "node --max_old_space_size=8192 ./node_modules/.bin/webpack --config webpack.config.js",
+    "build:dev": "npm run build:base -- --mode=development",
+    "build:prod": "npm run build:base -- --mode=production",
     "analyze": "./scripts/webpack-analyze.sh",
     "lint": "eslint ."
   },

--- a/packages/vendor/readme.md
+++ b/packages/vendor/readme.md
@@ -30,6 +30,10 @@ module.exports = {
 };
 ```
 
+> **Notice:** When using the plugin with `NODE_ENV=development` it will use the development versions of the provided 3rd-parties.
+>
+> Usefull when using webpack-dev-server
+
 ### Stylesheets
 
 `@theforeman/vendor` based on patternfly-react. It build the patternfly-react partials into the `./dist/foreman-vendor.bundle.css` and provides their variables and mixins sets to reuse.
@@ -45,11 +49,43 @@ See [@theforeman/vendor-dev](/packages/vendor-dev) for development installation.
 
 ## Building
 
-This project use `webpack` to produce bundled `javascript` and `css` files together with a `manifest.json`.
+This project use `webpack` to produce `development` and `production` versions of bundled `javascript` and `css` files together with a `manifest.json`.
 To build them into the `./dist` folder, run:
 
 ```sh
+# build production and development
 npm run build
+# build production
+npm run build:prod
+# build development
+npm run build:dev
+```
+
+Running `npm run build` will produce a `./dist` folder with the following files:
+```sh
+packages/vendor/dist
+├── foreman-vendor.bundle-v0.1.0-alpha.4-development-e226acdcab8caadcc978.css
+├── foreman-vendor.bundle-v0.1.0-alpha.4-development-e226acdcab8caadcc978.css.gz
+├── foreman-vendor.bundle-v0.1.0-alpha.4-development-e226acdcab8caadcc978.css.map
+├── foreman-vendor.bundle-v0.1.0-alpha.4-development-e226acdcab8caadcc978.css.map.gz
+├── foreman-vendor.bundle-v0.1.0-alpha.4-development-e226acdcab8caadcc978.js
+├── foreman-vendor.bundle-v0.1.0-alpha.4-development-e226acdcab8caadcc978.js.gz
+├── foreman-vendor.bundle-v0.1.0-alpha.4-development-e226acdcab8caadcc978.js.map
+├── foreman-vendor.bundle-v0.1.0-alpha.4-development-e226acdcab8caadcc978.js.map.gz
+├── foreman-vendor.bundle-v0.1.0-alpha.4-production-d4e23bdf5115757910bc.css
+├── foreman-vendor.bundle-v0.1.0-alpha.4-production-d4e23bdf5115757910bc.css.gz
+├── foreman-vendor.bundle-v0.1.0-alpha.4-production-d4e23bdf5115757910bc.css.map
+├── foreman-vendor.bundle-v0.1.0-alpha.4-production-d4e23bdf5115757910bc.css.map.gz
+├── foreman-vendor.bundle-v0.1.0-alpha.4-production-d4e23bdf5115757910bc.js
+├── foreman-vendor.bundle-v0.1.0-alpha.4-production-d4e23bdf5115757910bc.js.gz
+├── foreman-vendor.bundle-v0.1.0-alpha.4-production-d4e23bdf5115757910bc.js.map
+├── foreman-vendor.bundle-v0.1.0-alpha.4-production-d4e23bdf5115757910bc.js.map.gz
+├── manifest.development.json
+├── manifest.development.json.gz
+├── manifest.production.json
+└── manifest.production.json.gz
+
+0 directories, 20 files
 ```
 
 ### Build Analyzer

--- a/packages/vendor/webpack.config.js
+++ b/packages/vendor/webpack.config.js
@@ -8,11 +8,13 @@ const { version } = require('./package.json');
 const createVendorEntry = require('./lib/createVendorEntry');
 const WebpackExportForemanVendorPlugin = require('./lib/WebpackExportForemanVendorPlugin');
 
-const filename = `[name].bundle-v${version}-[hash]`;
+const [, webpackMode = 'production'] = process.argv
+  .find(arg => arg.startsWith('--mode='))
+  .split('=');
+
+const filename = `[name].bundle-v${version}-${webpackMode}-[hash]`;
 
 const config = {
-  mode: 'production',
-
   entry: {
     'foreman-vendor': createVendorEntry(),
   },
@@ -57,7 +59,7 @@ const config = {
 
   plugins: [
     new StatsWriterPlugin({
-      filename: 'manifest.json',
+      filename: `manifest.${webpackMode}.json`,
       fields: null,
       transform(data, opts) {
         return JSON.stringify(data.assetsByChunkName);

--- a/packages/vendor/webpack.plugin.js
+++ b/packages/vendor/webpack.plugin.js
@@ -1,10 +1,10 @@
 /* eslint-disable class-methods-use-this */
-const path = require('path');
 const CopyWebpackPlugin = require('copy-webpack-plugin');
 
+const Manifest = require('./lib/Manifest');
 const createWebpackExternals = require('./lib/createWebpackExternals');
-// eslint-disable-next-line import/no-unresolved
-const vendorManifest = require('./dist/manifest.json');
+
+const manifest = new Manifest(process.env.NODE_ENV);
 
 /**
  * Build for webpack@3
@@ -15,13 +15,7 @@ class WebpackExportForemanVendorPlugin {
    * copy vendor-dist files to the consumer output path
    */
   applyCopyFiles(compiler) {
-    new CopyWebpackPlugin([
-      {
-        from: path.join(__dirname, 'dist/*'),
-        flatten: true,
-        ignore: ['manifest.json'],
-      },
-    ]).apply(compiler);
+    new CopyWebpackPlugin(manifest.files).apply(compiler);
   }
 
   /**
@@ -54,7 +48,7 @@ class WebpackExportForemanVendorPlugin {
     manifestPlugin.opts.transform = (data, opts) => {
       data.assetsByChunkName = Object.assign(
         {},
-        vendorManifest,
+        manifest.data,
         data.assetsByChunkName
       );
 


### PR DESCRIPTION
Builds development and production dist files.
See #4 

## PR Type

* [x] Bugfix
* [x] Feature
* [ ] Code style update (whitespace, formatting, missing semicolons, etc.)
* [ ] Refactoring (no functional changes, no api changes)
* [x] Build related changes
* [ ] CI related changes
* [ ] Documentation content changes
* [ ] Other… Please describe:

## Description

This PR do 2 things:

1. When running `npm run build` it will create 2 different builds and 2 different `manifest.json` into the `dist` folder so my dist folder now looks as well:
```sh
packages/vendor/dist
├── foreman-vendor.bundle-v0.1.0-alpha.4-development-e226acdcab8caadcc978.css
├── foreman-vendor.bundle-v0.1.0-alpha.4-development-e226acdcab8caadcc978.css.gz
├── foreman-vendor.bundle-v0.1.0-alpha.4-development-e226acdcab8caadcc978.css.map
├── foreman-vendor.bundle-v0.1.0-alpha.4-development-e226acdcab8caadcc978.css.map.gz
├── foreman-vendor.bundle-v0.1.0-alpha.4-development-e226acdcab8caadcc978.js
├── foreman-vendor.bundle-v0.1.0-alpha.4-development-e226acdcab8caadcc978.js.gz
├── foreman-vendor.bundle-v0.1.0-alpha.4-development-e226acdcab8caadcc978.js.map
├── foreman-vendor.bundle-v0.1.0-alpha.4-development-e226acdcab8caadcc978.js.map.gz
├── foreman-vendor.bundle-v0.1.0-alpha.4-production-d4e23bdf5115757910bc.css
├── foreman-vendor.bundle-v0.1.0-alpha.4-production-d4e23bdf5115757910bc.css.gz
├── foreman-vendor.bundle-v0.1.0-alpha.4-production-d4e23bdf5115757910bc.css.map
├── foreman-vendor.bundle-v0.1.0-alpha.4-production-d4e23bdf5115757910bc.css.map.gz
├── foreman-vendor.bundle-v0.1.0-alpha.4-production-d4e23bdf5115757910bc.js
├── foreman-vendor.bundle-v0.1.0-alpha.4-production-d4e23bdf5115757910bc.js.gz
├── foreman-vendor.bundle-v0.1.0-alpha.4-production-d4e23bdf5115757910bc.js.map
├── foreman-vendor.bundle-v0.1.0-alpha.4-production-d4e23bdf5115757910bc.js.map.gz
├── manifest.development.json
├── manifest.development.json.gz
├── manifest.production.json
└── manifest.production.json.gz

0 directories, 20 files
```

2. When the consumer uses the `webpack.plugin.js`, it will detect the consumer `NODE_ENV` to decide between consuming `development` or `production`.

## How Has This Been Tested?

Tested against https://github.com/theforeman/foreman/pull/6605

## Does this PR introduce a breaking change?

* [ ] Yes
* [x] No

## Checklist:

<!--- Put an `x` in all the boxes that apply. -->

<!--- If you‘re unsure about any of these, don‘t hesitate to ask. We‘re here to help! -->

* [x] My change requires a change to the documentation.
* [x] I have updated the documentation accordingly.
* [x] I have read the [`contributing.md`](https://github.com/theforeman/foreman-js/blob/master/contributing.md).
