### PR TITLE
Fixes #7 - remove npm run link

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,5 +3,6 @@ notifications:
   email: false
 node_js: 10
 script:
-  - npm run build
+  - npm run lint
   - npm run test
+  - npm run build

--- a/package.json
+++ b/package.json
@@ -9,9 +9,6 @@
     "lerna": "lerna",
     "clean": "lerna clean",
     "bootstrap": "lerna bootstrap",
-    "link": "npm run link:out && npm run link:in",
-    "link:in": "lerna link",
-    "link:out": "lerna exec npm link",
     "build": "node --max_old_space_size=8192 ./node_modules/.bin/lerna run build",
     "test": "lerna run test",
     "lint": "lerna run lint"

--- a/packages/vendor-core/vendor-core
+++ b/packages/vendor-core/vendor-core
@@ -1,1 +1,0 @@
-../foreman-js/packages/vendor-core

--- a/packages/vendor-dev/package-lock.json
+++ b/packages/vendor-dev/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@theforeman/vendor-dev",
-	"version": "0.1.0-alpha.2",
+	"version": "0.1.0-alpha.4",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
@@ -72,21 +72,6 @@
 			"integrity": "sha512-ZmMhJfU/+SXXvy9ALjDZopa3T3EixQtQai89JRC48eM9OUwrxJjYjuM/0wmdl2AekytlzMVhPY8cYdLb13kpKQ==",
 			"dev": true
 		},
-		"@babel/runtime": {
-			"version": "7.4.4",
-			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.4.4.tgz",
-			"integrity": "sha512-w0+uT71b6Yi7i5SE0co4NioIpSYS6lLiXvCzWzGSKvpK5vdQtCbICHMj+gbAKAOtxiV6HsVh/MBdaF9EQ6faSg==",
-			"requires": {
-				"regenerator-runtime": "^0.13.2"
-			},
-			"dependencies": {
-				"regenerator-runtime": {
-					"version": "0.13.2",
-					"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.2.tgz",
-					"integrity": "sha512-S/TQAZJO+D3m9xeN1WTI8dLKBBiRgXBlTJvbWjCThHWZj9EvHK70Ff50/tYj2J/fvBY6JtFVwRuazHN2E7M9BA=="
-				}
-			}
-		},
 		"@babel/template": {
 			"version": "7.4.0",
 			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.4.0.tgz",
@@ -136,319 +121,6 @@
 				"lodash": "^4.17.11",
 				"to-fast-properties": "^2.0.0"
 			}
-		},
-		"@novnc/novnc": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/@novnc/novnc/-/novnc-1.1.0.tgz",
-			"integrity": "sha512-W90Q79EuCYT++39aT/VKGyk7hUt2gPN3rN+ifPUvY4rdjgZlfwdCg9q7yzj04hke/zgdHsbXFfyFijBvrRuU5A=="
-		},
-		"@theforeman/vendor-core": {
-			"version": "0.1.0-alpha.2",
-			"resolved": "https://registry.npmjs.org/@theforeman/vendor-core/-/vendor-core-0.1.0-alpha.2.tgz",
-			"integrity": "sha512-Ppw+QMCGwyeT6HLGFA8nDnGcWIZJ1dIci78l3dglQmmv0rK6ENEfLAaSOKEwX5DfixvSOMvq97jJW79RDNufmw==",
-			"requires": {
-				"@novnc/novnc": "^1.0.0",
-				"axios": "^0.17.1",
-				"babel-plugin-transform-rename-import": "^2.3.0",
-				"babel-polyfill": "^6.26.0",
-				"bootstrap-sass": "^3.4.1",
-				"brace": "^0.10.0",
-				"classnames": "^2.2.5",
-				"datatables.net": "~1.10.12",
-				"datatables.net-bs": "~1.10.12",
-				"diff": "~3.0.0",
-				"eslint-import-resolver-alias": "^1.1.2",
-				"ipaddr.js": "~1.2.0",
-				"isomorphic-fetch": "^2.2.1",
-				"jquery": "~2.2.4",
-				"jquery-flot": "~0.8.3",
-				"jquery-ujs": "~1.2.0",
-				"jquery.cookie": "~1.4.1",
-				"jstz": "~1.0.7",
-				"lodash": "^4.17.11",
-				"multiselect": "~0.9.12",
-				"number_helpers": "^0.1.1",
-				"patternfly": "^3.58.0",
-				"patternfly-react": "^2.30.6",
-				"prop-types": "^15.6.0",
-				"react": "^16.8.1",
-				"react-bootstrap": "0.32.1",
-				"react-debounce-input": "^3.2.0",
-				"react-diff-view": "^1.8.1",
-				"react-dom": "^16.8.1",
-				"react-ellipsis-with-tooltip": "^1.0.8",
-				"react-numeric-input": "^2.0.7",
-				"react-onclickoutside": "^6.6.2",
-				"react-password-strength": "^2.1.0",
-				"react-redux": "^5.0.6",
-				"redux": "^3.6.0",
-				"redux-form": "7.2.0",
-				"redux-form-validators": "^2.1.2",
-				"redux-logger": "^2.8.1",
-				"redux-thunk": "^2.2.0",
-				"seamless-immutable": "^7.1.2",
-				"select2": "~3.5.2-browserify",
-				"urijs": "^1.18.10",
-				"uuid": "^3.3.2"
-			}
-		},
-		"@types/c3": {
-			"version": "0.6.4",
-			"resolved": "https://registry.npmjs.org/@types/c3/-/c3-0.6.4.tgz",
-			"integrity": "sha512-W7i7oSmHsXYhseZJsIYexelv9HitGsWdQhx3mcy4NWso+GedpCYr02ghpkNvnZ4oTIjNeISdrOnM70s7HiuV+g==",
-			"optional": true,
-			"requires": {
-				"@types/d3": "^4"
-			}
-		},
-		"@types/d3": {
-			"version": "4.13.2",
-			"resolved": "https://registry.npmjs.org/@types/d3/-/d3-4.13.2.tgz",
-			"integrity": "sha512-jaMix9nFUgLeBSdU0md3usx5BaZfnO9Z0idyRmEq7mo7Ux7FpenW1SvyLXI0e59BtrgyPGNHMaZ0y2rJcSCMiw==",
-			"optional": true,
-			"requires": {
-				"@types/d3-array": "^1",
-				"@types/d3-axis": "*",
-				"@types/d3-brush": "*",
-				"@types/d3-chord": "*",
-				"@types/d3-collection": "*",
-				"@types/d3-color": "*",
-				"@types/d3-dispatch": "*",
-				"@types/d3-drag": "*",
-				"@types/d3-dsv": "*",
-				"@types/d3-ease": "*",
-				"@types/d3-force": "*",
-				"@types/d3-format": "*",
-				"@types/d3-geo": "*",
-				"@types/d3-hierarchy": "*",
-				"@types/d3-interpolate": "*",
-				"@types/d3-path": "*",
-				"@types/d3-polygon": "*",
-				"@types/d3-quadtree": "*",
-				"@types/d3-queue": "*",
-				"@types/d3-random": "*",
-				"@types/d3-request": "*",
-				"@types/d3-scale": "^1",
-				"@types/d3-selection": "*",
-				"@types/d3-shape": "*",
-				"@types/d3-time": "*",
-				"@types/d3-time-format": "*",
-				"@types/d3-timer": "*",
-				"@types/d3-transition": "*",
-				"@types/d3-voronoi": "*",
-				"@types/d3-zoom": "*"
-			}
-		},
-		"@types/d3-array": {
-			"version": "1.2.7",
-			"resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-1.2.7.tgz",
-			"integrity": "sha512-51vHWuUyDOi+8XuwPrTw3cFqyh2Slg9y8COYkRfjCPG9TfYqY0hoNPzv/8BrcAy0FeQBzqEo/D/8Nk2caOQJnA==",
-			"optional": true
-		},
-		"@types/d3-axis": {
-			"version": "1.0.12",
-			"resolved": "https://registry.npmjs.org/@types/d3-axis/-/d3-axis-1.0.12.tgz",
-			"integrity": "sha512-BZISgSD5M8TgURyNtcPAmUB9sk490CO1Thb6/gIn0WZTt3Y50IssX+2Z0vTccoqZksUDTep0b+o4ofXslvNbqg==",
-			"optional": true,
-			"requires": {
-				"@types/d3-selection": "*"
-			}
-		},
-		"@types/d3-brush": {
-			"version": "1.0.10",
-			"resolved": "https://registry.npmjs.org/@types/d3-brush/-/d3-brush-1.0.10.tgz",
-			"integrity": "sha512-J8jREATIrfJaAfhJivqaEKPnJsRlwwrOPje+ABqZFgamADjll+q9zaDXnYyjiGPPsiJEU+Qq9jQi5rECxIOfhg==",
-			"optional": true,
-			"requires": {
-				"@types/d3-selection": "*"
-			}
-		},
-		"@types/d3-chord": {
-			"version": "1.0.9",
-			"resolved": "https://registry.npmjs.org/@types/d3-chord/-/d3-chord-1.0.9.tgz",
-			"integrity": "sha512-UA6lI9CVW5cT5Ku/RV4hxoFn4mKySHm7HEgodtfRthAj1lt9rKZEPon58vyYfk+HIAm33DtJJgZwMXy2QgyPXw==",
-			"optional": true
-		},
-		"@types/d3-collection": {
-			"version": "1.0.8",
-			"resolved": "https://registry.npmjs.org/@types/d3-collection/-/d3-collection-1.0.8.tgz",
-			"integrity": "sha512-y5lGlazdc0HNO0F3UUX2DPE7OmYvd9Kcym4hXwrJcNUkDaypR5pX+apuMikl9LfTxKItJsY9KYvzBulpCKyvuQ==",
-			"optional": true
-		},
-		"@types/d3-color": {
-			"version": "1.2.2",
-			"resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-1.2.2.tgz",
-			"integrity": "sha512-6pBxzJ8ZP3dYEQ4YjQ+NVbQaOflfgXq/JbDiS99oLobM2o72uAST4q6yPxHv6FOTCRC/n35ktuo8pvw/S4M7sw=="
-		},
-		"@types/d3-dispatch": {
-			"version": "1.0.7",
-			"resolved": "https://registry.npmjs.org/@types/d3-dispatch/-/d3-dispatch-1.0.7.tgz",
-			"integrity": "sha512-M+z84G7UKwK6hEPnGCSccOg8zJ3Nk2hgDQ9sCstHXgsFU0sMxlIZVKqKB5oxUDbALqQG6ucg0G9e8cmOSlishg==",
-			"optional": true
-		},
-		"@types/d3-drag": {
-			"version": "1.2.3",
-			"resolved": "https://registry.npmjs.org/@types/d3-drag/-/d3-drag-1.2.3.tgz",
-			"integrity": "sha512-rWB5SPvkYVxW3sqUxHOJUZwifD0KqvKwvt1bhNqcLpW6Azsd0BJgRNcyVW8GAferaAk5r8dzeZnf9zKlg9+xMQ==",
-			"optional": true,
-			"requires": {
-				"@types/d3-selection": "*"
-			}
-		},
-		"@types/d3-dsv": {
-			"version": "1.0.36",
-			"resolved": "https://registry.npmjs.org/@types/d3-dsv/-/d3-dsv-1.0.36.tgz",
-			"integrity": "sha512-jbIWQ27QJcBNMZbQv0NSQMHnBDCmxghAxePxgyiPH1XPCRkOsTBei7jcdi3fDrUCGpCV3lKrSZFSlOkhUQVClA=="
-		},
-		"@types/d3-ease": {
-			"version": "1.0.8",
-			"resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-1.0.8.tgz",
-			"integrity": "sha512-VRf8czVWHSJPoUWxMunzpePK02//wHDAswknU8QWzcyrQn6pqe46bHRYi2smSpw5VjsT2CG8k/QeWIdWPS3Bmg==",
-			"optional": true
-		},
-		"@types/d3-force": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/@types/d3-force/-/d3-force-1.2.1.tgz",
-			"integrity": "sha512-jqK+I36uz4kTBjyk39meed5y31Ab+tXYN/x1dn3nZEus9yOHCLc+VrcIYLc/aSQ0Y7tMPRlIhLetulME76EiiA==",
-			"optional": true
-		},
-		"@types/d3-format": {
-			"version": "1.3.1",
-			"resolved": "https://registry.npmjs.org/@types/d3-format/-/d3-format-1.3.1.tgz",
-			"integrity": "sha512-KAWvReOKMDreaAwOjdfQMm0HjcUMlQG47GwqdVKgmm20vTd2pucj0a70c3gUSHrnsmo6H2AMrkBsZU2UhJLq8A==",
-			"optional": true
-		},
-		"@types/d3-geo": {
-			"version": "1.11.1",
-			"resolved": "https://registry.npmjs.org/@types/d3-geo/-/d3-geo-1.11.1.tgz",
-			"integrity": "sha512-Ox8WWOG3igDRoep/dNsGbOiSJYdUG3ew/6z0ETvHyAtXZVBjOE0S96zSSmzgl0gqQ3RdZjn2eeJOj9oRcMZPkQ==",
-			"optional": true,
-			"requires": {
-				"@types/geojson": "*"
-			}
-		},
-		"@types/d3-hierarchy": {
-			"version": "1.1.6",
-			"resolved": "https://registry.npmjs.org/@types/d3-hierarchy/-/d3-hierarchy-1.1.6.tgz",
-			"integrity": "sha512-vvSaIDf/Ov0o3KwMT+1M8+WbnnlRiGjlGD5uvk83a1mPCTd/E5x12bUJ/oP55+wUY/4Kb5kc67rVpVGJ2KUHxg==",
-			"optional": true
-		},
-		"@types/d3-interpolate": {
-			"version": "1.3.1",
-			"resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-1.3.1.tgz",
-			"integrity": "sha512-z8Zmi08XVwe8e62vP6wcA+CNuRhpuUU5XPEfqpG0hRypDE5BWNthQHB1UNWWDB7ojCbGaN4qBdsWp5kWxhT1IQ==",
-			"requires": {
-				"@types/d3-color": "*"
-			}
-		},
-		"@types/d3-path": {
-			"version": "1.0.8",
-			"resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-1.0.8.tgz",
-			"integrity": "sha512-AZGHWslq/oApTAHu9+yH/Bnk63y9oFOMROtqPAtxl5uB6qm1x2lueWdVEjsjjV3Qc2+QfuzKIwIR5MvVBakfzA=="
-		},
-		"@types/d3-polygon": {
-			"version": "1.0.7",
-			"resolved": "https://registry.npmjs.org/@types/d3-polygon/-/d3-polygon-1.0.7.tgz",
-			"integrity": "sha512-Xuw0eSjQQKs8jTiNbntWH0S+Xp+JyhqxmQ0YAQ3rDu6c3kKMFfgsaGN7Jv5u3zG6yVX/AsLP/Xs/QRjmi9g43Q==",
-			"optional": true
-		},
-		"@types/d3-quadtree": {
-			"version": "1.0.7",
-			"resolved": "https://registry.npmjs.org/@types/d3-quadtree/-/d3-quadtree-1.0.7.tgz",
-			"integrity": "sha512-0ajFawWicfjsaCLh6NzxOyVDYhQAmMFbsiI3MPGLInorauHFEh9/Cl6UHNf+kt/J1jfoxKY/ZJaKAoDpbvde5Q==",
-			"optional": true
-		},
-		"@types/d3-queue": {
-			"version": "3.0.8",
-			"resolved": "https://registry.npmjs.org/@types/d3-queue/-/d3-queue-3.0.8.tgz",
-			"integrity": "sha512-1FWOiI/MYwS5Z1Sa9EvS1Xet3isiVIIX5ozD6iGnwHonGcqL+RcC1eThXN5VfDmAiYt9Me9EWNEv/9J9k9RIKQ==",
-			"optional": true
-		},
-		"@types/d3-random": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/@types/d3-random/-/d3-random-1.1.2.tgz",
-			"integrity": "sha512-Jui+Zn28pQw/3EayPKaN4c/PqTvqNbIPjHkgIIFnxne1FdwNjfHtAIsZIBMKlquQNrrMjFzCrlF2gPs3xckqaA==",
-			"optional": true
-		},
-		"@types/d3-request": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/@types/d3-request/-/d3-request-1.0.5.tgz",
-			"integrity": "sha512-X+/c/qXp92o056C5Qbcp7jL27YRHpmIqOchHb/WB7NwFFqkBtAircqO7oKWv2GTtX4LyEqiDF9gqXsV+ldOlIg==",
-			"optional": true,
-			"requires": {
-				"@types/d3-dsv": "*"
-			}
-		},
-		"@types/d3-scale": {
-			"version": "1.0.14",
-			"resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-1.0.14.tgz",
-			"integrity": "sha512-dW6Ii8bH+10klJzVVPPeeQvRpCbX3BO3x9cLTngu/+lXNDbk2uC51aFAA/XhocehZroaG5ajwAFelMFsgpClMg==",
-			"optional": true,
-			"requires": {
-				"@types/d3-time": "*"
-			}
-		},
-		"@types/d3-selection": {
-			"version": "1.4.1",
-			"resolved": "https://registry.npmjs.org/@types/d3-selection/-/d3-selection-1.4.1.tgz",
-			"integrity": "sha512-bv8IfFYo/xG6dxri9OwDnK3yCagYPeRIjTlrcdYJSx+FDWlCeBDepIHUpqROmhPtZ53jyna0aUajZRk0I3rXNA=="
-		},
-		"@types/d3-shape": {
-			"version": "1.3.1",
-			"resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-1.3.1.tgz",
-			"integrity": "sha512-usqdvUvPJ7AJNwpd2drOzRKs1ELie53p2m2GnPKr076/ADM579jVTJ5dPsoZ5E/CMNWk8lvPWYQSvilpp6jjwg==",
-			"optional": true,
-			"requires": {
-				"@types/d3-path": "*"
-			}
-		},
-		"@types/d3-time": {
-			"version": "1.0.10",
-			"resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-1.0.10.tgz",
-			"integrity": "sha512-aKf62rRQafDQmSiv1NylKhIMmznsjRN+MnXRXTqHoqm0U/UZzVpdrtRnSIfdiLS616OuC1soYeX1dBg2n1u8Xw=="
-		},
-		"@types/d3-time-format": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/@types/d3-time-format/-/d3-time-format-2.1.1.tgz",
-			"integrity": "sha512-tJSyXta8ZyJ52wDDHA96JEsvkbL6jl7wowGmuf45+fAkj5Y+SQOnz0N7/H68OWmPshPsAaWMQh+GAws44IzH3g==",
-			"optional": true
-		},
-		"@types/d3-timer": {
-			"version": "1.0.9",
-			"resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-1.0.9.tgz",
-			"integrity": "sha512-WvfJ3LFxBbWjqRGz9n7GJt08RrTHPJDVsIwwoCMROlqF+iDacYiAFjf9oqnq0mXpb2juA2N/qjKP+MKdal3YNQ==",
-			"optional": true
-		},
-		"@types/d3-transition": {
-			"version": "1.1.4",
-			"resolved": "https://registry.npmjs.org/@types/d3-transition/-/d3-transition-1.1.4.tgz",
-			"integrity": "sha512-/vsmKVUIXEyCcIXYAlw7bnYkIs9/J/nZbptRJFKUN3FdXq/dF6j9z9xXzerkyU6TDHLrMrwx9eGwdKyTIy/j9w==",
-			"optional": true,
-			"requires": {
-				"@types/d3-selection": "*"
-			}
-		},
-		"@types/d3-voronoi": {
-			"version": "1.1.9",
-			"resolved": "https://registry.npmjs.org/@types/d3-voronoi/-/d3-voronoi-1.1.9.tgz",
-			"integrity": "sha512-DExNQkaHd1F3dFPvGA/Aw2NGyjMln6E9QzsiqOcBgnE+VInYnFBHBBySbZQts6z6xD+5jTfKCP7M4OqMyVjdwQ==",
-			"optional": true
-		},
-		"@types/d3-zoom": {
-			"version": "1.7.4",
-			"resolved": "https://registry.npmjs.org/@types/d3-zoom/-/d3-zoom-1.7.4.tgz",
-			"integrity": "sha512-5jnFo/itYhJeB2khO/lKe730kW/h2EbKMOvY0uNp3+7NdPm4w63DwPEMxifQZ7n902xGYK5DdU67FmToSoy4VA==",
-			"optional": true,
-			"requires": {
-				"@types/d3-interpolate": "*",
-				"@types/d3-selection": "*"
-			}
-		},
-		"@types/geojson": {
-			"version": "7946.0.7",
-			"resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.7.tgz",
-			"integrity": "sha512-wE2v81i4C4Ol09RtsWFAqg3BUitWbHSpSlIo+bNdsCJijO9sjme+zm+73ZMCa/qMC8UEERxzGbvmr1cffo2SiQ==",
-			"optional": true
 		},
 		"acorn": {
 			"version": "6.1.1",
@@ -524,11 +196,6 @@
 				"es-abstract": "^1.7.0"
 			}
 		},
-		"asap": {
-			"version": "2.0.6",
-			"resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
-			"integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY="
-		},
 		"ast-types-flow": {
 			"version": "0.0.7",
 			"resolved": "https://registry.npmjs.org/ast-types-flow/-/ast-types-flow-0.0.7.tgz",
@@ -540,15 +207,6 @@
 			"resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-1.0.0.tgz",
 			"integrity": "sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg==",
 			"dev": true
-		},
-		"axios": {
-			"version": "0.17.1",
-			"resolved": "https://registry.npmjs.org/axios/-/axios-0.17.1.tgz",
-			"integrity": "sha1-LY4+XQvb1zJ/kbyBT1xXZg+Bgk0=",
-			"requires": {
-				"follow-redirects": "^1.2.5",
-				"is-buffer": "^1.1.5"
-			}
 		},
 		"axobject-query": {
 			"version": "2.0.2",
@@ -590,96 +248,11 @@
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-rename-import/-/babel-plugin-transform-rename-import-2.3.0.tgz",
 			"integrity": "sha512-dPgJoT57XC0PqSnLgl2FwNvxFrWlspatX2dkk7yjKQj5HHGw071vAcOf+hqW8ClqcBDMvEbm6mevn5yHAD8mlQ=="
 		},
-		"babel-polyfill": {
-			"version": "6.26.0",
-			"resolved": "https://registry.npmjs.org/babel-polyfill/-/babel-polyfill-6.26.0.tgz",
-			"integrity": "sha1-N5k3q8Z9eJWXCtxiHyhM2WbPIVM=",
-			"requires": {
-				"babel-runtime": "^6.26.0",
-				"core-js": "^2.5.0",
-				"regenerator-runtime": "^0.10.5"
-			}
-		},
-		"babel-runtime": {
-			"version": "6.26.0",
-			"resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
-			"integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
-			"requires": {
-				"core-js": "^2.4.0",
-				"regenerator-runtime": "^0.11.0"
-			},
-			"dependencies": {
-				"regenerator-runtime": {
-					"version": "0.11.1",
-					"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
-					"integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg=="
-				}
-			}
-		},
 		"balanced-match": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
 			"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
 			"dev": true
-		},
-		"bootstrap": {
-			"version": "3.4.1",
-			"resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-3.4.1.tgz",
-			"integrity": "sha512-yN5oZVmRCwe5aKwzRj6736nSmKDX7pLYwsXiCj/EYmo16hODaBiT4En5btW/jhBF/seV+XMx3aYwukYC3A49DA=="
-		},
-		"bootstrap-datepicker": {
-			"version": "1.9.0",
-			"resolved": "https://registry.npmjs.org/bootstrap-datepicker/-/bootstrap-datepicker-1.9.0.tgz",
-			"integrity": "sha512-9rYYbaVOheGYxjOr/+bJCmRPihfy+LkLSg4fIFMT9Od8WwWB/MB50w0JO1eBgKUMbb7PFHQD5uAfI3ArAxZRXA==",
-			"optional": true,
-			"requires": {
-				"jquery": ">=1.7.1 <4.0.0"
-			}
-		},
-		"bootstrap-sass": {
-			"version": "3.4.1",
-			"resolved": "https://registry.npmjs.org/bootstrap-sass/-/bootstrap-sass-3.4.1.tgz",
-			"integrity": "sha512-p5rxsK/IyEDQm2CwiHxxUi0MZZtvVFbhWmyMOt4lLkA4bujDA1TGoKT0i1FKIWiugAdP+kK8T5KMDFIKQCLYIA=="
-		},
-		"bootstrap-select": {
-			"version": "1.12.2",
-			"resolved": "https://registry.npmjs.org/bootstrap-select/-/bootstrap-select-1.12.2.tgz",
-			"integrity": "sha1-WNCVs/1YSzFEOGb745tv3U5OEqQ=",
-			"optional": true,
-			"requires": {
-				"jquery": ">=1.8"
-			}
-		},
-		"bootstrap-slider": {
-			"version": "9.10.0",
-			"resolved": "https://registry.npmjs.org/bootstrap-slider/-/bootstrap-slider-9.10.0.tgz",
-			"integrity": "sha1-EQPWvADPv6jPyaJZmrUYxVZD2j8=",
-			"optional": true
-		},
-		"bootstrap-slider-without-jquery": {
-			"version": "10.0.0",
-			"resolved": "https://registry.npmjs.org/bootstrap-slider-without-jquery/-/bootstrap-slider-without-jquery-10.0.0.tgz",
-			"integrity": "sha512-CB9CrpNVrIytlOoqHtRXhhxFo/jencr1U5cMqPBA0WmMdb13bzjHnXQVNGYde/g5gWW+RWiuT9jTquZuz3VE8A=="
-		},
-		"bootstrap-switch": {
-			"version": "3.3.5",
-			"resolved": "https://registry.npmjs.org/bootstrap-switch/-/bootstrap-switch-3.3.5.tgz",
-			"integrity": "sha512-aRwgTPO7QPvTtUxit2ucXgs/P+dp3Y8Qy41XOOqTXZiJvfI6b87+hP+r4B4+3y7bptu0P6KHIyEc4ordEVIVkg==",
-			"optional": true
-		},
-		"bootstrap-touchspin": {
-			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/bootstrap-touchspin/-/bootstrap-touchspin-3.1.1.tgz",
-			"integrity": "sha1-l3nerHKq9Xfl52K4USx0fIcdlZc=",
-			"optional": true
-		},
-		"brace": {
-			"version": "0.10.0",
-			"resolved": "https://registry.npmjs.org/brace/-/brace-0.10.0.tgz",
-			"integrity": "sha1-7e9OubCSi6HuX3F//BV3SabdXXY=",
-			"requires": {
-				"w3c-blob": "0.0.1"
-			}
 		},
 		"brace-expansion": {
 			"version": "1.1.11",
@@ -689,19 +262,6 @@
 			"requires": {
 				"balanced-match": "^1.0.0",
 				"concat-map": "0.0.1"
-			}
-		},
-		"breakjs": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/breakjs/-/breakjs-1.0.0.tgz",
-			"integrity": "sha1-7INToGhi60OWLergkHLuZqTNhFk="
-		},
-		"c3": {
-			"version": "0.4.23",
-			"resolved": "https://registry.npmjs.org/c3/-/c3-0.4.23.tgz",
-			"integrity": "sha512-fI6hbx1QoATU0gRQtPWsUGWX+ssXhxGH1ogew32KjVmGHFE4WmfmBkh+RkuHDoeCIoGFon7XTpKcwUZpBGW4mQ==",
-			"requires": {
-				"d3": "~3.5.0"
 			}
 		},
 		"callsites": {
@@ -721,21 +281,11 @@
 				"supports-color": "^5.3.0"
 			}
 		},
-		"change-emitter": {
-			"version": "0.1.6",
-			"resolved": "https://registry.npmjs.org/change-emitter/-/change-emitter-0.1.6.tgz",
-			"integrity": "sha1-6LL+PX8at9aaMhma/5HqaTFAlRU="
-		},
 		"chardet": {
 			"version": "0.7.0",
 			"resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
 			"integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
 			"dev": true
-		},
-		"classnames": {
-			"version": "2.2.6",
-			"resolved": "https://registry.npmjs.org/classnames/-/classnames-2.2.6.tgz",
-			"integrity": "sha512-JR/iSQOSt+LQIWwrwEzJ9uk0xfN3mTVYMwt1Ir5mUcSN6pU+V4zQFFaJsclJbPuAUQH+yfWef6tm7l1quW3C8Q=="
 		},
 		"cli-cursor": {
 			"version": "2.1.0",
@@ -785,20 +335,6 @@
 			"integrity": "sha1-/ozxhP9mcLa67wGp1IYaXL7EEgo=",
 			"dev": true
 		},
-		"core-js": {
-			"version": "2.6.7",
-			"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.7.tgz",
-			"integrity": "sha512-ydmsQxDVH7lDpYoirXft8S83ddKKfdsrsmWhtyj7xafXVLbLhKOyfD7kAi2ueFfeP7m9rNavjW59O3hLLzzC5A=="
-		},
-		"create-react-context": {
-			"version": "0.2.3",
-			"resolved": "https://registry.npmjs.org/create-react-context/-/create-react-context-0.2.3.tgz",
-			"integrity": "sha512-CQBmD0+QGgTaxDL3OX1IDXYqjkp2It4RIbcb99jS6AEg27Ga+a9G3JtK6SIu0HBwPLZlmwt9F7UwWA4Bn92Rag==",
-			"requires": {
-				"fbjs": "^0.8.0",
-				"gud": "^1.0.0"
-			}
-		},
 		"cross-spawn": {
 			"version": "6.0.5",
 			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
@@ -812,87 +348,11 @@
 				"which": "^1.2.9"
 			}
 		},
-		"css-element-queries": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/css-element-queries/-/css-element-queries-1.2.0.tgz",
-			"integrity": "sha512-4gaxpioSFueMcp9yj1TJFCLjfooGv38y6ZdwFUS3GuS+9NIVijdeiExXKwSIHoQDADfpgnaYSTzmJs+bV+Hehg=="
-		},
-		"d3": {
-			"version": "3.5.17",
-			"resolved": "https://registry.npmjs.org/d3/-/d3-3.5.17.tgz",
-			"integrity": "sha1-vEZ0gAQ3iyGjYMn8fPUjF5B2L7g="
-		},
 		"damerau-levenshtein": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/damerau-levenshtein/-/damerau-levenshtein-1.0.4.tgz",
 			"integrity": "sha1-AxkcQyy27qFou3fzpV/9zLiXhRQ=",
 			"dev": true
-		},
-		"datatables.net": {
-			"version": "1.10.19",
-			"resolved": "https://registry.npmjs.org/datatables.net/-/datatables.net-1.10.19.tgz",
-			"integrity": "sha512-+ljXcI6Pj3PTGy5pesp3E5Dr3x3AV45EZe0o1r0gKENN2gafBKXodVnk2ypKwl2tTmivjxbkiqoWnipTefyBTA==",
-			"requires": {
-				"jquery": ">=1.7"
-			}
-		},
-		"datatables.net-bs": {
-			"version": "1.10.19",
-			"resolved": "https://registry.npmjs.org/datatables.net-bs/-/datatables.net-bs-1.10.19.tgz",
-			"integrity": "sha512-5gxoI2n+duZP06+4xVC2TtH6zcY369/TRKTZ1DdSgDcDUl4OYQsrXCuaLJmbVzna/5Y5lrMmK7CxgvYgIynICA==",
-			"requires": {
-				"datatables.net": "1.10.19",
-				"jquery": ">=1.7"
-			}
-		},
-		"datatables.net-colreorder": {
-			"version": "1.5.1",
-			"resolved": "https://registry.npmjs.org/datatables.net-colreorder/-/datatables.net-colreorder-1.5.1.tgz",
-			"integrity": "sha512-nKV0ZBOdOG+CCrtDZZlTOvhu9NC53pr4rYR8Xhd3KIKipLZohWWdBoOFGMu+VKDvllg2Xj79oS/wicYSiNyteA==",
-			"optional": true,
-			"requires": {
-				"datatables.net": "^1.10.15",
-				"jquery": ">=1.7"
-			}
-		},
-		"datatables.net-colreorder-bs": {
-			"version": "1.3.3",
-			"resolved": "https://registry.npmjs.org/datatables.net-colreorder-bs/-/datatables.net-colreorder-bs-1.3.3.tgz",
-			"integrity": "sha1-Op3LCN7r612FQHlZHgbkk615OlM=",
-			"optional": true,
-			"requires": {
-				"datatables.net-bs": ">=1.10.9",
-				"datatables.net-colreorder": ">=1.2.0",
-				"jquery": ">=1.7"
-			}
-		},
-		"datatables.net-select": {
-			"version": "1.2.7",
-			"resolved": "https://registry.npmjs.org/datatables.net-select/-/datatables.net-select-1.2.7.tgz",
-			"integrity": "sha512-C3XDi7wpruGjDXV36dc9hN/FrAX9GOFvBZ7+KfKJTBNkGFbbhdzHS91SMeGiwRXPYivAyxfPTcVVndVaO83uBQ==",
-			"optional": true,
-			"requires": {
-				"datatables.net": "^1.10.15",
-				"jquery": ">=1.7"
-			}
-		},
-		"debug": {
-			"version": "3.2.6",
-			"resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
-			"integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
-			"requires": {
-				"ms": "^2.1.1"
-			}
-		},
-		"deep-diff": {
-			"version": "0.3.4",
-			"resolved": "https://registry.npmjs.org/deep-diff/-/deep-diff-0.3.4.tgz",
-			"integrity": "sha1-qsXDmVIjar5fA3ojSQYLoBsArkg="
-		},
-		"deep-equal": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz",
-			"integrity": "sha1-9dJgKStmDghO/0zbyfCK0yR0SLU="
 		},
 		"deep-is": {
 			"version": "0.1.3",
@@ -909,11 +369,6 @@
 				"object-keys": "^1.0.12"
 			}
 		},
-		"diff": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/diff/-/diff-3.0.1.tgz",
-			"integrity": "sha1-pS2QzAiVaZS+AId7/5cRAGJYLDU="
-		},
 		"doctrine": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
@@ -923,48 +378,11 @@
 				"esutils": "^2.0.2"
 			}
 		},
-		"dom-helpers": {
-			"version": "3.4.0",
-			"resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-3.4.0.tgz",
-			"integrity": "sha512-LnuPJ+dwqKDIyotW1VzmOZ5TONUN7CwkCR5hrgawTUbkBGYdeoNLZo6nNfGkCrjtE1nXXaj7iMMpDa8/d9WoIA==",
-			"requires": {
-				"@babel/runtime": "^7.1.2"
-			}
-		},
-		"drmonty-datatables-colvis": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/drmonty-datatables-colvis/-/drmonty-datatables-colvis-1.1.2.tgz",
-			"integrity": "sha1-lque37SGQ8wu3aP4e4iTPN7oEnw=",
-			"optional": true,
-			"requires": {
-				"jquery": ">=1.7.0"
-			}
-		},
 		"emoji-regex": {
 			"version": "7.0.3",
 			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
 			"integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
 			"dev": true
-		},
-		"encoding": {
-			"version": "0.1.12",
-			"resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
-			"integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
-			"requires": {
-				"iconv-lite": "~0.4.13"
-			}
-		},
-		"eonasdan-bootstrap-datetimepicker": {
-			"version": "4.17.47",
-			"resolved": "https://registry.npmjs.org/eonasdan-bootstrap-datetimepicker/-/eonasdan-bootstrap-datetimepicker-4.17.47.tgz",
-			"integrity": "sha1-ekmXAEQGUnbnll79Fvgic1IZ5zU=",
-			"optional": true,
-			"requires": {
-				"bootstrap": "^3.3",
-				"jquery": "^1.8.3 || ^2.0 || ^3.0",
-				"moment": "^2.10",
-				"moment-timezone": "^0.4.0"
-			}
 		},
 		"error-ex": {
 			"version": "1.3.2",
@@ -1000,15 +418,11 @@
 				"is-symbol": "^1.0.2"
 			}
 		},
-		"es6-error": {
-			"version": "4.1.1",
-			"resolved": "https://registry.npmjs.org/es6-error/-/es6-error-4.1.1.tgz",
-			"integrity": "sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg=="
-		},
 		"escape-string-regexp": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-			"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+			"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+			"dev": true
 		},
 		"eslint": {
 			"version": "5.15.3",
@@ -1446,27 +860,6 @@
 			"integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
 			"dev": true
 		},
-		"fbjs": {
-			"version": "0.8.17",
-			"resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.17.tgz",
-			"integrity": "sha1-xNWY6taUkRJlPWWIsBpc3Nn5D90=",
-			"requires": {
-				"core-js": "^1.0.0",
-				"isomorphic-fetch": "^2.1.1",
-				"loose-envify": "^1.0.0",
-				"object-assign": "^4.1.0",
-				"promise": "^7.1.1",
-				"setimmediate": "^1.0.5",
-				"ua-parser-js": "^0.7.18"
-			},
-			"dependencies": {
-				"core-js": {
-					"version": "1.2.7",
-					"resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
-					"integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY="
-				}
-			}
-		},
 		"figures": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
@@ -1511,25 +904,6 @@
 			"integrity": "sha512-R+H8IZclI8AAkSBRQJLVOsxwAoHd6WC40b4QTNWIjzAa6BXOBfQcM587MXDTVPeYaopFNWHUFLx7eNmHDSxMWg==",
 			"dev": true
 		},
-		"follow-redirects": {
-			"version": "1.7.0",
-			"resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.7.0.tgz",
-			"integrity": "sha512-m/pZQy4Gj287eNy94nivy5wchN3Kp+Q5WgUPNy5lJSZ3sgkVKSYV/ZChMAQVIgx1SqfZ2zBZtPA2YlXIWxxJOQ==",
-			"requires": {
-				"debug": "^3.2.6"
-			}
-		},
-		"font-awesome": {
-			"version": "4.7.0",
-			"resolved": "https://registry.npmjs.org/font-awesome/-/font-awesome-4.7.0.tgz",
-			"integrity": "sha1-j6jPBBGhoxr9B7BtKQK7n8gVoTM="
-		},
-		"font-awesome-sass": {
-			"version": "4.7.0",
-			"resolved": "https://registry.npmjs.org/font-awesome-sass/-/font-awesome-sass-4.7.0.tgz",
-			"integrity": "sha1-TtppPpFQCc4Asijglk3F7Km8NOE=",
-			"optional": true
-		},
 		"fs.realpath": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -1554,11 +928,6 @@
 			"integrity": "sha1-Ei4WFZHiH/TFJTAwVpPyDmOTo5g=",
 			"dev": true
 		},
-		"gitdiff-parser": {
-			"version": "0.1.2",
-			"resolved": "https://registry.npmjs.org/gitdiff-parser/-/gitdiff-parser-0.1.2.tgz",
-			"integrity": "sha512-glDM6E1AwLYYTOPyI0CqamNEUSuwwAkmwULWpE2sHMpMZNzGJwErt7+eV+yIZcsbDza0pVSlwlBHFWbTf2Wu7A=="
-		},
 		"glob": {
 			"version": "7.1.3",
 			"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
@@ -1579,22 +948,11 @@
 			"integrity": "sha512-WHq43gS+6ufNOEqlrDBxVEbb8ntfXrfAUU2ZOpCxrBdGKW3gyv8mCxAfIBD0DroPKGrJ2eSsXsLtY9MPntsyTw==",
 			"dev": true
 		},
-		"google-code-prettify": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/google-code-prettify/-/google-code-prettify-1.0.5.tgz",
-			"integrity": "sha1-n0d/Ik2/piNy5e+AOn4VdBBAAIQ=",
-			"optional": true
-		},
 		"graceful-fs": {
 			"version": "4.1.15",
 			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.15.tgz",
 			"integrity": "sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA==",
 			"dev": true
-		},
-		"gud": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/gud/-/gud-1.0.0.tgz",
-			"integrity": "sha512-zGEOVKFM5sVPPrYs7J5/hYEw2Pof8KCyOwyhG8sAF26mCAeUFAcYPu1mwB7hhpIP29zOIBaDqwuHdLp0jvZXjw=="
 		},
 		"has": {
 			"version": "1.0.3",
@@ -1617,11 +975,6 @@
 			"integrity": "sha1-uhqPGvKg/DllD1yFA2dwQSIGO0Q=",
 			"dev": true
 		},
-		"hoist-non-react-statics": {
-			"version": "2.5.5",
-			"resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-2.5.5.tgz",
-			"integrity": "sha512-rqcy4pJo55FTTLWt+bU8ukscqHeE/e9KWvsOW2b/a3afxQZhwkQdT1rPPCJ0rYXdj4vNcasY8zHTH+jF/qStxw=="
-		},
 		"hosted-git-info": {
 			"version": "2.7.1",
 			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.7.1.tgz",
@@ -1632,6 +985,7 @@
 			"version": "0.4.24",
 			"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
 			"integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+			"dev": true,
 			"requires": {
 				"safer-buffer": ">= 2.1.2 < 3"
 			}
@@ -1712,29 +1066,11 @@
 				}
 			}
 		},
-		"invariant": {
-			"version": "2.2.4",
-			"resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
-			"integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
-			"requires": {
-				"loose-envify": "^1.0.0"
-			}
-		},
-		"ipaddr.js": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.2.0.tgz",
-			"integrity": "sha1-irpJyRknmVhb3WQ+DMtQ6K53e6Q="
-		},
 		"is-arrayish": {
 			"version": "0.2.1",
 			"resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
 			"integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
 			"dev": true
-		},
-		"is-buffer": {
-			"version": "1.1.6",
-			"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-			"integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
 		},
 		"is-callable": {
 			"version": "1.1.4",
@@ -1757,7 +1093,8 @@
 		"is-promise": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz",
-			"integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o="
+			"integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o=",
+			"dev": true
 		},
 		"is-regex": {
 			"version": "1.0.4",
@@ -1767,11 +1104,6 @@
 			"requires": {
 				"has": "^1.0.1"
 			}
-		},
-		"is-stream": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-			"integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
 		},
 		"is-symbol": {
 			"version": "1.0.2",
@@ -1794,54 +1126,17 @@
 			"integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
 			"dev": true
 		},
-		"isomorphic-fetch": {
-			"version": "2.2.1",
-			"resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
-			"integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=",
-			"requires": {
-				"node-fetch": "^1.0.1",
-				"whatwg-fetch": ">=0.10.0"
-			}
-		},
 		"jest-docblock": {
 			"version": "21.2.0",
 			"resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-21.2.0.tgz",
 			"integrity": "sha512-5IZ7sY9dBAYSV+YjQ0Ovb540Ku7AO9Z5o2Cg789xj167iQuZ2cG+z0f3Uct6WeYLbU6aQiM2pCs7sZ+4dotydw==",
 			"dev": true
 		},
-		"jquery": {
-			"version": "2.2.4",
-			"resolved": "https://registry.npmjs.org/jquery/-/jquery-2.2.4.tgz",
-			"integrity": "sha1-LInWiJterFIqfuoywUUhVZxsvwI="
-		},
-		"jquery-flot": {
-			"version": "0.8.3",
-			"resolved": "https://registry.npmjs.org/jquery-flot/-/jquery-flot-0.8.3.tgz",
-			"integrity": "sha1-onOs9D8TGQ9ueHAYae4kv+8Swio="
-		},
-		"jquery-match-height": {
-			"version": "0.7.2",
-			"resolved": "https://registry.npmjs.org/jquery-match-height/-/jquery-match-height-0.7.2.tgz",
-			"integrity": "sha1-+NnzulMU2qsQnPB0CGdL4gS+Xw4=",
-			"optional": true
-		},
-		"jquery-ujs": {
-			"version": "1.2.2",
-			"resolved": "https://registry.npmjs.org/jquery-ujs/-/jquery-ujs-1.2.2.tgz",
-			"integrity": "sha1-ao7xAg5rbdo4W5CkvdwSjCHFY5c=",
-			"requires": {
-				"jquery": ">=1.8.0"
-			}
-		},
-		"jquery.cookie": {
-			"version": "1.4.1",
-			"resolved": "https://registry.npmjs.org/jquery.cookie/-/jquery.cookie-1.4.1.tgz",
-			"integrity": "sha1-1j3OIJ6raR/mMxbbCMqeR+D5OFs="
-		},
 		"js-tokens": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-			"integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
+			"integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+			"dev": true
 		},
 		"js-yaml": {
 			"version": "3.12.2",
@@ -1871,11 +1166,6 @@
 			"integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
 			"dev": true
 		},
-		"jstz": {
-			"version": "1.0.11",
-			"resolved": "https://registry.npmjs.org/jstz/-/jstz-1.0.11.tgz",
-			"integrity": "sha512-TII4P76PQfjffpzl3mk6SyqOr0sUqK+zWm1GLv505j9vXNfAPxKC5uWa/hwcPJ0mZvuP3u2xjm3OGuKRlEw/Yw=="
-		},
 		"jsx-ast-utils": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-2.0.1.tgz",
@@ -1884,16 +1174,6 @@
 			"requires": {
 				"array-includes": "^3.0.3"
 			}
-		},
-		"keycode": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/keycode/-/keycode-2.2.0.tgz",
-			"integrity": "sha1-PQr1bce4uOXLqNCpfxByBO7CKwQ="
-		},
-		"leven": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/leven/-/leven-2.1.0.tgz",
-			"integrity": "sha1-wuep93IJTe6dNCAq6KzORoeHVYA="
 		},
 		"levn": {
 			"version": "0.3.0",
@@ -1930,37 +1210,14 @@
 		"lodash": {
 			"version": "4.17.11",
 			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-			"integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
-		},
-		"lodash-es": {
-			"version": "4.17.11",
-			"resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.11.tgz",
-			"integrity": "sha512-DHb1ub+rMjjrxqlB3H56/6MXtm1lSksDp2rA2cNWjG8mlDUYFhUj3Di2Zn5IwSU87xLv8tNIQ7sSwE/YOX/D/Q=="
-		},
-		"lodash.debounce": {
-			"version": "4.0.8",
-			"resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
-			"integrity": "sha1-gteb/zCmfEAF/9XiUVMArZyk168="
-		},
-		"lodash.escape": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-4.0.1.tgz",
-			"integrity": "sha1-yQRGkMIeBClL6qUXcS/e0fqI3pg="
-		},
-		"lodash.findlastindex": {
-			"version": "4.6.0",
-			"resolved": "https://registry.npmjs.org/lodash.findlastindex/-/lodash.findlastindex-4.6.0.tgz",
-			"integrity": "sha1-uDdawPAum5Jjdc343D6oFKv5xqw="
-		},
-		"lodash.mapvalues": {
-			"version": "4.6.0",
-			"resolved": "https://registry.npmjs.org/lodash.mapvalues/-/lodash.mapvalues-4.6.0.tgz",
-			"integrity": "sha1-G6+lAF3p3W9PJmaMMMo3IwzJaJw="
+			"integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
+			"dev": true
 		},
 		"loose-envify": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
 			"integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+			"dev": true,
 			"requires": {
 				"js-tokens": "^3.0.0 || ^4.0.0"
 			}
@@ -1995,32 +1252,11 @@
 				"minimist": "0.0.8"
 			}
 		},
-		"moment": {
-			"version": "2.24.0",
-			"resolved": "https://registry.npmjs.org/moment/-/moment-2.24.0.tgz",
-			"integrity": "sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg=="
-		},
-		"moment-timezone": {
-			"version": "0.4.1",
-			"resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.4.1.tgz",
-			"integrity": "sha1-gfWYw61eIs2teWtn7NjYjQ9bqgY=",
-			"optional": true,
-			"requires": {
-				"moment": ">= 2.6.0"
-			}
-		},
 		"ms": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-			"integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
-		},
-		"multiselect": {
-			"version": "0.9.12",
-			"resolved": "https://registry.npmjs.org/multiselect/-/multiselect-0.9.12.tgz",
-			"integrity": "sha1-0VU26YbdagApsWDWYTvO34Hkx+0=",
-			"requires": {
-				"jquery": ">= 1.7.1"
-			}
+			"integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+			"dev": true
 		},
 		"mute-stream": {
 			"version": "0.0.7",
@@ -2040,15 +1276,6 @@
 			"integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
 			"dev": true
 		},
-		"node-fetch": {
-			"version": "1.7.3",
-			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
-			"integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
-			"requires": {
-				"encoding": "^0.1.11",
-				"is-stream": "^1.0.1"
-			}
-		},
 		"normalize-package-data": {
 			"version": "2.5.0",
 			"resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
@@ -2061,15 +1288,11 @@
 				"validate-npm-package-license": "^3.0.1"
 			}
 		},
-		"number_helpers": {
-			"version": "0.1.1",
-			"resolved": "https://registry.npmjs.org/number_helpers/-/number_helpers-0.1.1.tgz",
-			"integrity": "sha1-GN7I2CYw0Fx8XfNdSThhfHrLrwU="
-		},
 		"object-assign": {
 			"version": "4.1.1",
 			"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-			"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
+			"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+			"dev": true
 		},
 		"object-keys": {
 			"version": "1.1.0",
@@ -2208,94 +1431,6 @@
 				"pify": "^2.0.0"
 			}
 		},
-		"patternfly": {
-			"version": "3.59.1",
-			"resolved": "https://registry.npmjs.org/patternfly/-/patternfly-3.59.1.tgz",
-			"integrity": "sha512-0Q/P58yaxcQXwnXo/OssiXaZmuX0g9QvWdpsYHyml4ihqnN2lL/yGdadFarA6UAQb//15XtNjKHZocoJXCkWYg==",
-			"requires": {
-				"@types/c3": "^0.6.0",
-				"bootstrap": "~3.4.0",
-				"bootstrap-datepicker": "^1.7.1",
-				"bootstrap-sass": "^3.4.0",
-				"bootstrap-select": "1.12.2",
-				"bootstrap-slider": "^9.9.0",
-				"bootstrap-switch": "~3.3.4",
-				"bootstrap-touchspin": "~3.1.1",
-				"c3": "~0.4.11",
-				"d3": "~3.5.17",
-				"datatables.net": "^1.10.15",
-				"datatables.net-colreorder": "^1.4.1",
-				"datatables.net-colreorder-bs": "~1.3.2",
-				"datatables.net-select": "~1.2.0",
-				"drmonty-datatables-colvis": "~1.1.2",
-				"eonasdan-bootstrap-datetimepicker": "^4.17.47",
-				"font-awesome": "^4.7.0",
-				"font-awesome-sass": "^4.7.0",
-				"google-code-prettify": "~1.0.5",
-				"jquery": "~3.2.1",
-				"jquery-match-height": "^0.7.2",
-				"moment": "^2.19.1",
-				"moment-timezone": "^0.4.1",
-				"patternfly-bootstrap-combobox": "~1.1.7",
-				"patternfly-bootstrap-treeview": "~2.1.0"
-			},
-			"dependencies": {
-				"jquery": {
-					"version": "3.2.1",
-					"resolved": "https://registry.npmjs.org/jquery/-/jquery-3.2.1.tgz",
-					"integrity": "sha1-XE2d5lKvbNCncBVKYxu6ErAVx4c="
-				}
-			}
-		},
-		"patternfly-bootstrap-combobox": {
-			"version": "1.1.7",
-			"resolved": "https://registry.npmjs.org/patternfly-bootstrap-combobox/-/patternfly-bootstrap-combobox-1.1.7.tgz",
-			"integrity": "sha1-al48zRFwwhs8S0qhaKdBPh3btuE=",
-			"optional": true
-		},
-		"patternfly-bootstrap-treeview": {
-			"version": "2.1.8",
-			"resolved": "https://registry.npmjs.org/patternfly-bootstrap-treeview/-/patternfly-bootstrap-treeview-2.1.8.tgz",
-			"integrity": "sha512-Z3v+zJ0AEhMiySyj7qgUs4yGM8afJwjUUWgwSosWI9xpMsyJV+B+I+GzgRoGiukzh14EOl3EiX4qqMBC+nwqXQ==",
-			"optional": true,
-			"requires": {
-				"bootstrap": "3.4.x",
-				"jquery": ">= 2.1.x"
-			}
-		},
-		"patternfly-react": {
-			"version": "2.34.3",
-			"resolved": "https://registry.npmjs.org/patternfly-react/-/patternfly-react-2.34.3.tgz",
-			"integrity": "sha512-5bdIBHpo1bdO3gsYC1tbmxeXX/NXe5ghBen3MCFeumUDZGtKmaoN5NOY+uGL6LtkWTCTA7heKXJxfFOuk/IXrA==",
-			"requires": {
-				"bootstrap-slider-without-jquery": "^10.0.0",
-				"breakjs": "^1.0.0",
-				"classnames": "^2.2.5",
-				"css-element-queries": "^1.0.1",
-				"lodash": "^4.17.11",
-				"patternfly": "^3.58.0",
-				"react-bootstrap": "^0.32.1",
-				"react-bootstrap-switch": "^15.5.3",
-				"react-bootstrap-typeahead": "^3.4.1",
-				"react-c3js": "^0.1.20",
-				"react-click-outside": "^3.0.1",
-				"react-collapse": "^4.0.3",
-				"react-debounce-input": "^3.2.0",
-				"react-ellipsis-with-tooltip": "^1.0.8",
-				"react-fontawesome": "^1.6.1",
-				"react-motion": "^0.5.2",
-				"reactabular-table": "^8.14.0",
-				"recompose": "^0.26.0",
-				"sortabular": "^1.5.1",
-				"table-resolver": "^3.2.0",
-				"uuid": "^3.3.2"
-			}
-		},
-		"performance-now": {
-			"version": "0.2.0",
-			"resolved": "https://registry.npmjs.org/performance-now/-/performance-now-0.2.0.tgz",
-			"integrity": "sha1-M+8wxcd9TqIcWlOGnZG1bY8lVeU="
-		},
 		"pify": {
 			"version": "2.3.0",
 			"resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
@@ -2310,11 +1445,6 @@
 			"requires": {
 				"find-up": "^2.1.0"
 			}
-		},
-		"popper.js": {
-			"version": "1.15.0",
-			"resolved": "https://registry.npmjs.org/popper.js/-/popper.js-1.15.0.tgz",
-			"integrity": "sha512-w010cY1oCUmI+9KwwlWki+r5jxKfTFDVoadl7MSrIujHU5MJ5OR6HTDj6Xo8aoR/QsA56x8jKjA59qGH4ELtrA=="
 		},
 		"prelude-ls": {
 			"version": "1.1.2",
@@ -2334,31 +1464,15 @@
 			"integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
 			"dev": true
 		},
-		"promise": {
-			"version": "7.3.1",
-			"resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
-			"integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
-			"requires": {
-				"asap": "~2.0.3"
-			}
-		},
 		"prop-types": {
 			"version": "15.7.2",
 			"resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
 			"integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
+			"dev": true,
 			"requires": {
 				"loose-envify": "^1.4.0",
 				"object-assign": "^4.1.1",
 				"react-is": "^16.8.1"
-			}
-		},
-		"prop-types-extra": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/prop-types-extra/-/prop-types-extra-1.1.0.tgz",
-			"integrity": "sha512-QFyuDxvMipmIVKD2TwxLVPzMnO4e5oOf1vr3tJIomL8E7d0lr6phTHd5nkPhFIzTD1idBLLEPeylL9g+rrTzRg==",
-			"requires": {
-				"react-is": "^16.3.2",
-				"warning": "^3.0.0"
 			}
 		},
 		"punycode": {
@@ -2367,301 +1481,11 @@
 			"integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
 			"dev": true
 		},
-		"raf": {
-			"version": "3.4.1",
-			"resolved": "https://registry.npmjs.org/raf/-/raf-3.4.1.tgz",
-			"integrity": "sha512-Sq4CW4QhwOHE8ucn6J34MqtZCeWFP2aQSmrlroYgqAV1PjStIhJXxYuTgUIfkEk7zTLjmIjLmU5q+fbD1NnOJA==",
-			"requires": {
-				"performance-now": "^2.1.0"
-			},
-			"dependencies": {
-				"performance-now": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
-					"integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
-				}
-			}
-		},
-		"react": {
-			"version": "16.8.6",
-			"resolved": "https://registry.npmjs.org/react/-/react-16.8.6.tgz",
-			"integrity": "sha512-pC0uMkhLaHm11ZSJULfOBqV4tIZkx87ZLvbbQYunNixAAvjnC+snJCg0XQXn9VIsttVsbZP/H/ewzgsd5fxKXw==",
-			"requires": {
-				"loose-envify": "^1.1.0",
-				"object-assign": "^4.1.1",
-				"prop-types": "^15.6.2",
-				"scheduler": "^0.13.6"
-			}
-		},
-		"react-bootstrap": {
-			"version": "0.32.1",
-			"resolved": "https://registry.npmjs.org/react-bootstrap/-/react-bootstrap-0.32.1.tgz",
-			"integrity": "sha512-RbfzKUbsukWsToWqGHfCCyMFq9QQI0TznutdyxyJw6dih2NvIne25Mrssg8LZsprqtPpyQi8bN0L0Fx3fUsL8Q==",
-			"requires": {
-				"babel-runtime": "^6.11.6",
-				"classnames": "^2.2.5",
-				"dom-helpers": "^3.2.0",
-				"invariant": "^2.2.1",
-				"keycode": "^2.1.2",
-				"prop-types": "^15.5.10",
-				"prop-types-extra": "^1.0.1",
-				"react-overlays": "^0.8.0",
-				"react-prop-types": "^0.4.0",
-				"react-transition-group": "^2.0.0",
-				"uncontrollable": "^4.1.0",
-				"warning": "^3.0.0"
-			}
-		},
-		"react-bootstrap-switch": {
-			"version": "15.5.3",
-			"resolved": "https://registry.npmjs.org/react-bootstrap-switch/-/react-bootstrap-switch-15.5.3.tgz",
-			"integrity": "sha1-lyh3kdTsDRiS0UJULn5SSAArElE="
-		},
-		"react-bootstrap-typeahead": {
-			"version": "3.4.3",
-			"resolved": "https://registry.npmjs.org/react-bootstrap-typeahead/-/react-bootstrap-typeahead-3.4.3.tgz",
-			"integrity": "sha512-/F37uKRWOL1IIo4EXCpL/1juHIG6Dzwl/gJlNJlqQGZMWMc/UNjB3DGg3loh3Gqfs4YHBgCu5SxhZWwgtLyRew==",
-			"requires": {
-				"classnames": "^2.2.0",
-				"create-react-context": "^0.2.3",
-				"escape-string-regexp": "^1.0.5",
-				"invariant": "^2.2.1",
-				"lodash": "^4.17.2",
-				"prop-types": "^15.5.8",
-				"prop-types-extra": "^1.0.1",
-				"react-overlays": "^0.8.1",
-				"react-popper": "^1.0.0",
-				"warning": "^4.0.1"
-			},
-			"dependencies": {
-				"warning": {
-					"version": "4.0.3",
-					"resolved": "https://registry.npmjs.org/warning/-/warning-4.0.3.tgz",
-					"integrity": "sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==",
-					"requires": {
-						"loose-envify": "^1.0.0"
-					}
-				}
-			}
-		},
-		"react-c3js": {
-			"version": "0.1.20",
-			"resolved": "https://registry.npmjs.org/react-c3js/-/react-c3js-0.1.20.tgz",
-			"integrity": "sha512-+jtEKJj6bFfD0pj3Vx0dDexpK3uGnZ/kLeJiuXYLBdHppx4tzpwAfMBDlQYQ5m4dqDi7jaovFaL2GX8vZRi+Gw==",
-			"requires": {
-				"c3": "^0.4.11"
-			}
-		},
-		"react-click-outside": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/react-click-outside/-/react-click-outside-3.0.1.tgz",
-			"integrity": "sha512-d0KWFvBt+esoZUF15rL2UBB7jkeAqLU8L/Ny35oLK6fW6mIbOv/ChD+ExF4sR9PD26kVx+9hNfD0FTIqRZEyRQ==",
-			"requires": {
-				"hoist-non-react-statics": "^2.1.1"
-			}
-		},
-		"react-collapse": {
-			"version": "4.0.3",
-			"resolved": "https://registry.npmjs.org/react-collapse/-/react-collapse-4.0.3.tgz",
-			"integrity": "sha512-OO4NhtEqFtz+1ma31J1B7+ezdRnzHCZiTGSSd/Pxoks9hxrZYhzFEddeYt05A/1477xTtdrwo7xEa2FLJyWGCQ==",
-			"requires": {
-				"prop-types": "^15.5.8"
-			}
-		},
-		"react-debounce-input": {
-			"version": "3.2.0",
-			"resolved": "https://registry.npmjs.org/react-debounce-input/-/react-debounce-input-3.2.0.tgz",
-			"integrity": "sha1-aXjGBh2Jj1SfQEF/sNLrvs9Qqqo=",
-			"requires": {
-				"lodash.debounce": "^4",
-				"prop-types": "^15"
-			}
-		},
-		"react-diff-view": {
-			"version": "1.8.1",
-			"resolved": "https://registry.npmjs.org/react-diff-view/-/react-diff-view-1.8.1.tgz",
-			"integrity": "sha512-+soJL85Xnsak/VOdxSgiDKhhaFiOkckiswwrXdiWVCxV3LP9POyJR4AqGVFGdkntJ3YT63mtwTYuunFeId+XSA==",
-			"requires": {
-				"classnames": "^2.2.6",
-				"gitdiff-parser": "^0.1.2",
-				"leven": "^2.1.0",
-				"lodash.escape": "^4.0.1",
-				"lodash.findlastindex": "^4.6.0",
-				"lodash.mapvalues": "^4.6.0",
-				"warning": "^4.0.1"
-			},
-			"dependencies": {
-				"warning": {
-					"version": "4.0.3",
-					"resolved": "https://registry.npmjs.org/warning/-/warning-4.0.3.tgz",
-					"integrity": "sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==",
-					"requires": {
-						"loose-envify": "^1.0.0"
-					}
-				}
-			}
-		},
-		"react-dom": {
-			"version": "16.8.6",
-			"resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.8.6.tgz",
-			"integrity": "sha512-1nL7PIq9LTL3fthPqwkvr2zY7phIPjYrT0jp4HjyEQrEROnw4dG41VVwi/wfoCneoleqrNX7iAD+pXebJZwrwA==",
-			"requires": {
-				"loose-envify": "^1.1.0",
-				"object-assign": "^4.1.1",
-				"prop-types": "^15.6.2",
-				"scheduler": "^0.13.6"
-			}
-		},
-		"react-ellipsis-with-tooltip": {
-			"version": "1.0.8",
-			"resolved": "https://registry.npmjs.org/react-ellipsis-with-tooltip/-/react-ellipsis-with-tooltip-1.0.8.tgz",
-			"integrity": "sha512-GdEYrrvS/iPYVAufShdJz8gtwG5kZNxlBh1Kb/LjCwYgNwGmRlCbVEmXS///bHrbhXoSxnzYbymGHFyYKR4Q6A==",
-			"requires": {
-				"uuid": "^3.1.0"
-			}
-		},
-		"react-fontawesome": {
-			"version": "1.6.1",
-			"resolved": "https://registry.npmjs.org/react-fontawesome/-/react-fontawesome-1.6.1.tgz",
-			"integrity": "sha1-7dzhfn3HMaoJ/UoYZoimF5OhbFw=",
-			"requires": {
-				"prop-types": "^15.5.6"
-			}
-		},
 		"react-is": {
 			"version": "16.8.4",
 			"resolved": "https://registry.npmjs.org/react-is/-/react-is-16.8.4.tgz",
-			"integrity": "sha512-PVadd+WaUDOAciICm/J1waJaSvgq+4rHE/K70j0PFqKhkTBsPv/82UGQJNXAngz1fOQLLxI6z1sEDmJDQhCTAA=="
-		},
-		"react-lifecycles-compat": {
-			"version": "3.0.4",
-			"resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
-			"integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA=="
-		},
-		"react-motion": {
-			"version": "0.5.2",
-			"resolved": "https://registry.npmjs.org/react-motion/-/react-motion-0.5.2.tgz",
-			"integrity": "sha512-9q3YAvHoUiWlP3cK0v+w1N5Z23HXMj4IF4YuvjvWegWqNPfLXsOBE/V7UvQGpXxHFKRQQcNcVQE31g9SB/6qgQ==",
-			"requires": {
-				"performance-now": "^0.2.0",
-				"prop-types": "^15.5.8",
-				"raf": "^3.1.0"
-			}
-		},
-		"react-numeric-input": {
-			"version": "2.2.3",
-			"resolved": "https://registry.npmjs.org/react-numeric-input/-/react-numeric-input-2.2.3.tgz",
-			"integrity": "sha1-S/WRjD6v7YUagN8euZLZQQArtVI="
-		},
-		"react-onclickoutside": {
-			"version": "6.8.0",
-			"resolved": "https://registry.npmjs.org/react-onclickoutside/-/react-onclickoutside-6.8.0.tgz",
-			"integrity": "sha512-5Q4Rn7QLEoh7WIe66KFvYIpWJ49GeHoygP1/EtJyZjXKgrWH19Tf0Ty3lWyQzrEEDyLOwUvvmBFSE3dcDdvagA=="
-		},
-		"react-overlays": {
-			"version": "0.8.3",
-			"resolved": "https://registry.npmjs.org/react-overlays/-/react-overlays-0.8.3.tgz",
-			"integrity": "sha512-h6GT3jgy90PgctleP39Yu3eK1v9vaJAW73GOA/UbN9dJ7aAN4BTZD6793eI1D5U+ukMk17qiqN/wl3diK1Z5LA==",
-			"requires": {
-				"classnames": "^2.2.5",
-				"dom-helpers": "^3.2.1",
-				"prop-types": "^15.5.10",
-				"prop-types-extra": "^1.0.1",
-				"react-transition-group": "^2.2.0",
-				"warning": "^3.0.0"
-			}
-		},
-		"react-password-strength": {
-			"version": "2.4.0",
-			"resolved": "https://registry.npmjs.org/react-password-strength/-/react-password-strength-2.4.0.tgz",
-			"integrity": "sha512-8ksh5zfF4uXRxJDGgleABu0dS5hN+mQSvzxLpVWEPVwWMxKikLEVUnB0mrbnBHul7mbjVD9QTjzQ78/wm5bewQ==",
-			"requires": {
-				"prop-types": "^15.6.0",
-				"zxcvbn": "^4.3.0"
-			}
-		},
-		"react-popper": {
-			"version": "1.3.3",
-			"resolved": "https://registry.npmjs.org/react-popper/-/react-popper-1.3.3.tgz",
-			"integrity": "sha512-ynMZBPkXONPc5K4P5yFWgZx5JGAUIP3pGGLNs58cfAPgK67olx7fmLp+AdpZ0+GoQ+ieFDa/z4cdV6u7sioH6w==",
-			"requires": {
-				"@babel/runtime": "^7.1.2",
-				"create-react-context": "<=0.2.2",
-				"popper.js": "^1.14.4",
-				"prop-types": "^15.6.1",
-				"typed-styles": "^0.0.7",
-				"warning": "^4.0.2"
-			},
-			"dependencies": {
-				"create-react-context": {
-					"version": "0.2.2",
-					"resolved": "https://registry.npmjs.org/create-react-context/-/create-react-context-0.2.2.tgz",
-					"integrity": "sha512-KkpaLARMhsTsgp0d2NA/R94F/eDLbhXERdIq3LvX2biCAXcDvHYoOqHfWCHf1+OLj+HKBotLG3KqaOOf+C1C+A==",
-					"requires": {
-						"fbjs": "^0.8.0",
-						"gud": "^1.0.0"
-					}
-				},
-				"warning": {
-					"version": "4.0.3",
-					"resolved": "https://registry.npmjs.org/warning/-/warning-4.0.3.tgz",
-					"integrity": "sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==",
-					"requires": {
-						"loose-envify": "^1.0.0"
-					}
-				}
-			}
-		},
-		"react-prop-types": {
-			"version": "0.4.0",
-			"resolved": "https://registry.npmjs.org/react-prop-types/-/react-prop-types-0.4.0.tgz",
-			"integrity": "sha1-+ZsL+0AGkpya8gUefBQUpcdbk9A=",
-			"requires": {
-				"warning": "^3.0.0"
-			}
-		},
-		"react-redux": {
-			"version": "5.1.1",
-			"resolved": "https://registry.npmjs.org/react-redux/-/react-redux-5.1.1.tgz",
-			"integrity": "sha512-LE7Ned+cv5qe7tMV5BPYkGQ5Lpg8gzgItK07c67yHvJ8t0iaD9kPFPAli/mYkiyJYrs2pJgExR2ZgsGqlrOApg==",
-			"requires": {
-				"@babel/runtime": "^7.1.2",
-				"hoist-non-react-statics": "^3.1.0",
-				"invariant": "^2.2.4",
-				"loose-envify": "^1.1.0",
-				"prop-types": "^15.6.1",
-				"react-is": "^16.6.0",
-				"react-lifecycles-compat": "^3.0.0"
-			},
-			"dependencies": {
-				"hoist-non-react-statics": {
-					"version": "3.3.0",
-					"resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.0.tgz",
-					"integrity": "sha512-0XsbTXxgiaCDYDIWFcwkmerZPSwywfUqYmwT4jzewKTQSWoE6FCMoUVOeBJWK3E/CrWbxRG3m5GzY4lnIwGRBA==",
-					"requires": {
-						"react-is": "^16.7.0"
-					}
-				}
-			}
-		},
-		"react-transition-group": {
-			"version": "2.9.0",
-			"resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-2.9.0.tgz",
-			"integrity": "sha512-+HzNTCHpeQyl4MJ/bdE0u6XRMe9+XG/+aL4mCxVN4DnPBQ0/5bfHWPDuOZUzYdMj94daZaZdCCc1Dzt9R/xSSg==",
-			"requires": {
-				"dom-helpers": "^3.4.0",
-				"loose-envify": "^1.4.0",
-				"prop-types": "^15.6.2",
-				"react-lifecycles-compat": "^3.0.4"
-			}
-		},
-		"reactabular-table": {
-			"version": "8.14.0",
-			"resolved": "https://registry.npmjs.org/reactabular-table/-/reactabular-table-8.14.0.tgz",
-			"integrity": "sha512-F3qOa7yJCi1hnxsESmo2QBWVl1RQfUfZhMhpG81zOxDQKsk/nsXlq/5aBtQ17NadYI6PDdMNourNs+255GpmFQ==",
-			"requires": {
-				"classnames": "^2.2.5"
-			}
+			"integrity": "sha512-PVadd+WaUDOAciICm/J1waJaSvgq+4rHE/K70j0PFqKhkTBsPv/82UGQJNXAngz1fOQLLxI6z1sEDmJDQhCTAA==",
+			"dev": true
 		},
 		"read-pkg": {
 			"version": "2.0.0",
@@ -2683,66 +1507,6 @@
 				"find-up": "^2.0.0",
 				"read-pkg": "^2.0.0"
 			}
-		},
-		"recompose": {
-			"version": "0.26.0",
-			"resolved": "https://registry.npmjs.org/recompose/-/recompose-0.26.0.tgz",
-			"integrity": "sha512-KwOu6ztO0mN5vy3+zDcc45lgnaUoaQse/a5yLVqtzTK13czSWnFGmXbQVmnoMgDkI5POd1EwIKSbjU1V7xdZog==",
-			"requires": {
-				"change-emitter": "^0.1.2",
-				"fbjs": "^0.8.1",
-				"hoist-non-react-statics": "^2.3.1",
-				"symbol-observable": "^1.0.4"
-			}
-		},
-		"redux": {
-			"version": "3.7.2",
-			"resolved": "https://registry.npmjs.org/redux/-/redux-3.7.2.tgz",
-			"integrity": "sha512-pNqnf9q1hI5HHZRBkj3bAngGZW/JMCmexDlOxw4XagXY2o1327nHH54LoTjiPJ0gizoqPDRqWyX/00g0hD6w+A==",
-			"requires": {
-				"lodash": "^4.2.1",
-				"lodash-es": "^4.2.1",
-				"loose-envify": "^1.1.0",
-				"symbol-observable": "^1.0.3"
-			}
-		},
-		"redux-form": {
-			"version": "7.2.0",
-			"resolved": "https://registry.npmjs.org/redux-form/-/redux-form-7.2.0.tgz",
-			"integrity": "sha512-qbgeI19drwnm9FeGAotDA1vsZO8q94XF7IxPDuJmSXxDYX2rqzhND6NROahCBJfBK5xM1cchvmgscO2rry1EEw==",
-			"requires": {
-				"deep-equal": "^1.0.1",
-				"es6-error": "^4.0.0",
-				"hoist-non-react-statics": "^2.3.1",
-				"invariant": "^2.2.2",
-				"is-promise": "^2.1.0",
-				"lodash": "^4.17.3",
-				"lodash-es": "^4.17.3",
-				"prop-types": "^15.5.9"
-			}
-		},
-		"redux-form-validators": {
-			"version": "2.7.5",
-			"resolved": "https://registry.npmjs.org/redux-form-validators/-/redux-form-validators-2.7.5.tgz",
-			"integrity": "sha512-WzEfcdIRcOAv+W33nNj1JDAU2UmV3RBR7RzbdqpUzdlOHhp9x+nCGUX+06TLLsWLBAVQma7FRJOFtmoYojTIDA=="
-		},
-		"redux-logger": {
-			"version": "2.10.2",
-			"resolved": "https://registry.npmjs.org/redux-logger/-/redux-logger-2.10.2.tgz",
-			"integrity": "sha1-PFpfCm8yV3wd6t9mVfJX+CxsOTc=",
-			"requires": {
-				"deep-diff": "0.3.4"
-			}
-		},
-		"redux-thunk": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-2.3.0.tgz",
-			"integrity": "sha512-km6dclyFnmcvxhAcrQV2AkZmPQjzPDjgVlQtR0EQjxZPyJ0BnMf3in1ryuR8A2qU0HldVRfxYXbFSKlI3N7Slw=="
-		},
-		"regenerator-runtime": {
-			"version": "0.10.5",
-			"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz",
-			"integrity": "sha1-M2w+/BIgrc7dosn6tntaeVWjNlg="
 		},
 		"regexpp": {
 			"version": "2.0.1",
@@ -2805,37 +1569,14 @@
 		"safer-buffer": {
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-			"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
-		},
-		"scheduler": {
-			"version": "0.13.6",
-			"resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.13.6.tgz",
-			"integrity": "sha512-IWnObHt413ucAYKsD9J1QShUKkbKLQQHdxRyw73sw4FN26iWr3DY/H34xGPe4nmL1DwXyWmSWmMrA9TfQbE/XQ==",
-			"requires": {
-				"loose-envify": "^1.1.0",
-				"object-assign": "^4.1.1"
-			}
-		},
-		"seamless-immutable": {
-			"version": "7.1.4",
-			"resolved": "https://registry.npmjs.org/seamless-immutable/-/seamless-immutable-7.1.4.tgz",
-			"integrity": "sha512-XiUO1QP4ki4E2PHegiGAlu6r82o5A+6tRh7IkGGTVg/h+UoeX4nFBeCGPOhb4CYjvkqsfm/TUtvOMYC1xmV30A=="
-		},
-		"select2": {
-			"version": "3.5.2-browserify",
-			"resolved": "https://registry.npmjs.org/select2/-/select2-3.5.2-browserify.tgz",
-			"integrity": "sha1-3E2v2jjWenNOipekbw01Ka4FOR0="
+			"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+			"dev": true
 		},
 		"semver": {
 			"version": "5.6.0",
 			"resolved": "https://registry.npmjs.org/semver/-/semver-5.6.0.tgz",
 			"integrity": "sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg==",
 			"dev": true
-		},
-		"setimmediate": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
-			"integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU="
 		},
 		"shebang-command": {
 			"version": "1.2.0",
@@ -2868,12 +1609,6 @@
 				"astral-regex": "^1.0.0",
 				"is-fullwidth-code-point": "^2.0.0"
 			}
-		},
-		"sortabular": {
-			"version": "1.6.0",
-			"resolved": "https://registry.npmjs.org/sortabular/-/sortabular-1.6.0.tgz",
-			"integrity": "sha512-rKOAXc3Z5JXCeMR1FV6Yuh5HSQUAUyMpEBni5qgO84FBv+C9p4yZ4GnHDhFTyfyMCo7qMS+ZF8ffzXApUOzTBg==",
-			"optional": true
 		},
 		"source-map": {
 			"version": "0.5.7",
@@ -2959,11 +1694,6 @@
 				"has-flag": "^3.0.0"
 			}
 		},
-		"symbol-observable": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.2.0.tgz",
-			"integrity": "sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ=="
-		},
 		"table": {
 			"version": "5.2.3",
 			"resolved": "https://registry.npmjs.org/table/-/table-5.2.3.tgz",
@@ -3003,12 +1733,6 @@
 					}
 				}
 			}
-		},
-		"table-resolver": {
-			"version": "3.3.0",
-			"resolved": "https://registry.npmjs.org/table-resolver/-/table-resolver-3.3.0.tgz",
-			"integrity": "sha512-BkdhtKYhWtXK54GeACs0khqlMvJ53puOw01tzIPsPUr3PP2pFeq9AelPUb7Iy7NeHMyIUI6vEfnngoWgEG+rLQ==",
-			"optional": true
 		},
 		"text-table": {
 			"version": "0.2.0",
@@ -3058,24 +1782,6 @@
 				"prelude-ls": "~1.1.2"
 			}
 		},
-		"typed-styles": {
-			"version": "0.0.7",
-			"resolved": "https://registry.npmjs.org/typed-styles/-/typed-styles-0.0.7.tgz",
-			"integrity": "sha512-pzP0PWoZUhsECYjABgCGQlRGL1n7tOHsgwYv3oIiEpJwGhFTuty/YNeduxQYzXXa3Ge5BdT6sHYIQYpl4uJ+5Q=="
-		},
-		"ua-parser-js": {
-			"version": "0.7.19",
-			"resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.19.tgz",
-			"integrity": "sha512-T3PVJ6uz8i0HzPxOF9SWzWAlfN/DavlpQqepn22xgve/5QecC+XMCAtmUNnY7C9StehaV6exjUCI801lOI7QlQ=="
-		},
-		"uncontrollable": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/uncontrollable/-/uncontrollable-4.1.0.tgz",
-			"integrity": "sha1-4DWCkSUuGGUiLZCTmxny9J+Bwak=",
-			"requires": {
-				"invariant": "^2.1.0"
-			}
-		},
 		"uri-js": {
 			"version": "4.2.2",
 			"resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
@@ -3084,16 +1790,6 @@
 			"requires": {
 				"punycode": "^2.1.0"
 			}
-		},
-		"urijs": {
-			"version": "1.19.1",
-			"resolved": "https://registry.npmjs.org/urijs/-/urijs-1.19.1.tgz",
-			"integrity": "sha512-xVrGVi94ueCJNrBSTjWqjvtgvl3cyOTThp2zaMaFNGp3F542TR6sM3f2o8RqZl+AwteClSVmoCyt0ka4RjQOQg=="
-		},
-		"uuid": {
-			"version": "3.3.2",
-			"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
-			"integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
 		},
 		"validate-npm-package-license": {
 			"version": "3.0.4",
@@ -3104,24 +1800,6 @@
 				"spdx-correct": "^3.0.0",
 				"spdx-expression-parse": "^3.0.0"
 			}
-		},
-		"w3c-blob": {
-			"version": "0.0.1",
-			"resolved": "https://registry.npmjs.org/w3c-blob/-/w3c-blob-0.0.1.tgz",
-			"integrity": "sha1-sM01KhpQ9RVWNCD/1YYflQ8dhbg="
-		},
-		"warning": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/warning/-/warning-3.0.0.tgz",
-			"integrity": "sha1-MuU3fLVy3kqwR1O9+IIcAe1gW3w=",
-			"requires": {
-				"loose-envify": "^1.0.0"
-			}
-		},
-		"whatwg-fetch": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.0.0.tgz",
-			"integrity": "sha512-9GSJUgz1D4MfyKU7KRqwOjXCXTqWdFNvEr7eUBYchQiVc744mqK/MzXPNR2WsPkmkOa4ywfg8C2n8h+13Bey1Q=="
 		},
 		"which": {
 			"version": "1.3.1",
@@ -3152,11 +1830,6 @@
 			"requires": {
 				"mkdirp": "^0.5.1"
 			}
-		},
-		"zxcvbn": {
-			"version": "4.4.2",
-			"resolved": "https://registry.npmjs.org/zxcvbn/-/zxcvbn-4.4.2.tgz",
-			"integrity": "sha1-KOwXzwl0PtyrBW3dixsGJizHPDA="
 		}
 	}
 }

--- a/packages/vendor-dev/vendor-dev
+++ b/packages/vendor-dev/vendor-dev
@@ -1,1 +1,0 @@
-../foreman-js/packages/vendor-dev

--- a/packages/vendor/package-lock.json
+++ b/packages/vendor/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@theforeman/vendor",
-  "version": "0.1.0-alpha.2",
+  "version": "0.1.0-alpha.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -80,23 +80,6 @@
       "integrity": "sha512-tXZCqWtlOOP4wgCp6RjRvLmfuhnqTLy9VHwRochJBCP2nDm27JnnuFEnXFASVyQNHk36jD1tAammsCEEqgscIQ==",
       "dev": true
     },
-    "@babel/runtime": {
-      "version": "7.4.4",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.4.4.tgz",
-      "integrity": "sha512-w0+uT71b6Yi7i5SE0co4NioIpSYS6lLiXvCzWzGSKvpK5vdQtCbICHMj+gbAKAOtxiV6HsVh/MBdaF9EQ6faSg==",
-      "dev": true,
-      "requires": {
-        "regenerator-runtime": "^0.13.2"
-      },
-      "dependencies": {
-        "regenerator-runtime": {
-          "version": "0.13.2",
-          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.2.tgz",
-          "integrity": "sha512-S/TQAZJO+D3m9xeN1WTI8dLKBBiRgXBlTJvbWjCThHWZj9EvHK70Ff50/tYj2J/fvBY6JtFVwRuazHN2E7M9BA==",
-          "dev": true
-        }
-      }
-    },
     "@babel/template": {
       "version": "7.2.2",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.2.2.tgz",
@@ -147,359 +130,11 @@
         "to-fast-properties": "^2.0.0"
       }
     },
-    "@novnc/novnc": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@novnc/novnc/-/novnc-1.1.0.tgz",
-      "integrity": "sha512-W90Q79EuCYT++39aT/VKGyk7hUt2gPN3rN+ifPUvY4rdjgZlfwdCg9q7yzj04hke/zgdHsbXFfyFijBvrRuU5A==",
-      "dev": true
-    },
-    "@theforeman/vendor-core": {
-      "version": "0.1.0-alpha.2",
-      "resolved": "https://registry.npmjs.org/@theforeman/vendor-core/-/vendor-core-0.1.0-alpha.2.tgz",
-      "integrity": "sha512-Ppw+QMCGwyeT6HLGFA8nDnGcWIZJ1dIci78l3dglQmmv0rK6ENEfLAaSOKEwX5DfixvSOMvq97jJW79RDNufmw==",
-      "dev": true,
-      "requires": {
-        "@novnc/novnc": "^1.0.0",
-        "axios": "^0.17.1",
-        "babel-plugin-transform-rename-import": "^2.3.0",
-        "babel-polyfill": "^6.26.0",
-        "bootstrap-sass": "^3.4.1",
-        "brace": "^0.10.0",
-        "classnames": "^2.2.5",
-        "datatables.net": "~1.10.12",
-        "datatables.net-bs": "~1.10.12",
-        "diff": "~3.0.0",
-        "eslint-import-resolver-alias": "^1.1.2",
-        "ipaddr.js": "~1.2.0",
-        "isomorphic-fetch": "^2.2.1",
-        "jquery": "~2.2.4",
-        "jquery-flot": "~0.8.3",
-        "jquery-ujs": "~1.2.0",
-        "jquery.cookie": "~1.4.1",
-        "jstz": "~1.0.7",
-        "lodash": "^4.17.11",
-        "multiselect": "~0.9.12",
-        "number_helpers": "^0.1.1",
-        "patternfly": "^3.58.0",
-        "patternfly-react": "^2.30.6",
-        "prop-types": "^15.6.0",
-        "react": "^16.8.1",
-        "react-bootstrap": "0.32.1",
-        "react-debounce-input": "^3.2.0",
-        "react-diff-view": "^1.8.1",
-        "react-dom": "^16.8.1",
-        "react-ellipsis-with-tooltip": "^1.0.8",
-        "react-numeric-input": "^2.0.7",
-        "react-onclickoutside": "^6.6.2",
-        "react-password-strength": "^2.1.0",
-        "react-redux": "^5.0.6",
-        "redux": "^3.6.0",
-        "redux-form": "7.2.0",
-        "redux-form-validators": "^2.1.2",
-        "redux-logger": "^2.8.1",
-        "redux-thunk": "^2.2.0",
-        "seamless-immutable": "^7.1.2",
-        "select2": "~3.5.2-browserify",
-        "urijs": "^1.18.10",
-        "uuid": "^3.3.2"
-      }
-    },
     "@types/anymatch": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/@types/anymatch/-/anymatch-1.3.1.tgz",
       "integrity": "sha512-/+CRPXpBDpo2RK9C68N3b2cOvO0Cf5B9aPijHsoDQTHivnGSObdOF2BRQOYjojWTDy6nQvMjmqRXIxH55VjxxA==",
       "dev": true
-    },
-    "@types/c3": {
-      "version": "0.6.4",
-      "resolved": "https://registry.npmjs.org/@types/c3/-/c3-0.6.4.tgz",
-      "integrity": "sha512-W7i7oSmHsXYhseZJsIYexelv9HitGsWdQhx3mcy4NWso+GedpCYr02ghpkNvnZ4oTIjNeISdrOnM70s7HiuV+g==",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "@types/d3": "^4"
-      }
-    },
-    "@types/d3": {
-      "version": "4.13.2",
-      "resolved": "https://registry.npmjs.org/@types/d3/-/d3-4.13.2.tgz",
-      "integrity": "sha512-jaMix9nFUgLeBSdU0md3usx5BaZfnO9Z0idyRmEq7mo7Ux7FpenW1SvyLXI0e59BtrgyPGNHMaZ0y2rJcSCMiw==",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "@types/d3-array": "^1",
-        "@types/d3-axis": "*",
-        "@types/d3-brush": "*",
-        "@types/d3-chord": "*",
-        "@types/d3-collection": "*",
-        "@types/d3-color": "*",
-        "@types/d3-dispatch": "*",
-        "@types/d3-drag": "*",
-        "@types/d3-dsv": "*",
-        "@types/d3-ease": "*",
-        "@types/d3-force": "*",
-        "@types/d3-format": "*",
-        "@types/d3-geo": "*",
-        "@types/d3-hierarchy": "*",
-        "@types/d3-interpolate": "*",
-        "@types/d3-path": "*",
-        "@types/d3-polygon": "*",
-        "@types/d3-quadtree": "*",
-        "@types/d3-queue": "*",
-        "@types/d3-random": "*",
-        "@types/d3-request": "*",
-        "@types/d3-scale": "^1",
-        "@types/d3-selection": "*",
-        "@types/d3-shape": "*",
-        "@types/d3-time": "*",
-        "@types/d3-time-format": "*",
-        "@types/d3-timer": "*",
-        "@types/d3-transition": "*",
-        "@types/d3-voronoi": "*",
-        "@types/d3-zoom": "*"
-      }
-    },
-    "@types/d3-array": {
-      "version": "1.2.7",
-      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-1.2.7.tgz",
-      "integrity": "sha512-51vHWuUyDOi+8XuwPrTw3cFqyh2Slg9y8COYkRfjCPG9TfYqY0hoNPzv/8BrcAy0FeQBzqEo/D/8Nk2caOQJnA==",
-      "dev": true,
-      "optional": true
-    },
-    "@types/d3-axis": {
-      "version": "1.0.12",
-      "resolved": "https://registry.npmjs.org/@types/d3-axis/-/d3-axis-1.0.12.tgz",
-      "integrity": "sha512-BZISgSD5M8TgURyNtcPAmUB9sk490CO1Thb6/gIn0WZTt3Y50IssX+2Z0vTccoqZksUDTep0b+o4ofXslvNbqg==",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "@types/d3-selection": "*"
-      }
-    },
-    "@types/d3-brush": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/@types/d3-brush/-/d3-brush-1.0.10.tgz",
-      "integrity": "sha512-J8jREATIrfJaAfhJivqaEKPnJsRlwwrOPje+ABqZFgamADjll+q9zaDXnYyjiGPPsiJEU+Qq9jQi5rECxIOfhg==",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "@types/d3-selection": "*"
-      }
-    },
-    "@types/d3-chord": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/@types/d3-chord/-/d3-chord-1.0.9.tgz",
-      "integrity": "sha512-UA6lI9CVW5cT5Ku/RV4hxoFn4mKySHm7HEgodtfRthAj1lt9rKZEPon58vyYfk+HIAm33DtJJgZwMXy2QgyPXw==",
-      "dev": true,
-      "optional": true
-    },
-    "@types/d3-collection": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/@types/d3-collection/-/d3-collection-1.0.8.tgz",
-      "integrity": "sha512-y5lGlazdc0HNO0F3UUX2DPE7OmYvd9Kcym4hXwrJcNUkDaypR5pX+apuMikl9LfTxKItJsY9KYvzBulpCKyvuQ==",
-      "dev": true,
-      "optional": true
-    },
-    "@types/d3-color": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-1.2.2.tgz",
-      "integrity": "sha512-6pBxzJ8ZP3dYEQ4YjQ+NVbQaOflfgXq/JbDiS99oLobM2o72uAST4q6yPxHv6FOTCRC/n35ktuo8pvw/S4M7sw==",
-      "dev": true
-    },
-    "@types/d3-dispatch": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/@types/d3-dispatch/-/d3-dispatch-1.0.7.tgz",
-      "integrity": "sha512-M+z84G7UKwK6hEPnGCSccOg8zJ3Nk2hgDQ9sCstHXgsFU0sMxlIZVKqKB5oxUDbALqQG6ucg0G9e8cmOSlishg==",
-      "dev": true,
-      "optional": true
-    },
-    "@types/d3-drag": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@types/d3-drag/-/d3-drag-1.2.3.tgz",
-      "integrity": "sha512-rWB5SPvkYVxW3sqUxHOJUZwifD0KqvKwvt1bhNqcLpW6Azsd0BJgRNcyVW8GAferaAk5r8dzeZnf9zKlg9+xMQ==",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "@types/d3-selection": "*"
-      }
-    },
-    "@types/d3-dsv": {
-      "version": "1.0.36",
-      "resolved": "https://registry.npmjs.org/@types/d3-dsv/-/d3-dsv-1.0.36.tgz",
-      "integrity": "sha512-jbIWQ27QJcBNMZbQv0NSQMHnBDCmxghAxePxgyiPH1XPCRkOsTBei7jcdi3fDrUCGpCV3lKrSZFSlOkhUQVClA==",
-      "dev": true
-    },
-    "@types/d3-ease": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-1.0.8.tgz",
-      "integrity": "sha512-VRf8czVWHSJPoUWxMunzpePK02//wHDAswknU8QWzcyrQn6pqe46bHRYi2smSpw5VjsT2CG8k/QeWIdWPS3Bmg==",
-      "dev": true,
-      "optional": true
-    },
-    "@types/d3-force": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@types/d3-force/-/d3-force-1.2.1.tgz",
-      "integrity": "sha512-jqK+I36uz4kTBjyk39meed5y31Ab+tXYN/x1dn3nZEus9yOHCLc+VrcIYLc/aSQ0Y7tMPRlIhLetulME76EiiA==",
-      "dev": true,
-      "optional": true
-    },
-    "@types/d3-format": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@types/d3-format/-/d3-format-1.3.1.tgz",
-      "integrity": "sha512-KAWvReOKMDreaAwOjdfQMm0HjcUMlQG47GwqdVKgmm20vTd2pucj0a70c3gUSHrnsmo6H2AMrkBsZU2UhJLq8A==",
-      "dev": true,
-      "optional": true
-    },
-    "@types/d3-geo": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@types/d3-geo/-/d3-geo-1.11.1.tgz",
-      "integrity": "sha512-Ox8WWOG3igDRoep/dNsGbOiSJYdUG3ew/6z0ETvHyAtXZVBjOE0S96zSSmzgl0gqQ3RdZjn2eeJOj9oRcMZPkQ==",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "@types/geojson": "*"
-      }
-    },
-    "@types/d3-hierarchy": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/@types/d3-hierarchy/-/d3-hierarchy-1.1.6.tgz",
-      "integrity": "sha512-vvSaIDf/Ov0o3KwMT+1M8+WbnnlRiGjlGD5uvk83a1mPCTd/E5x12bUJ/oP55+wUY/4Kb5kc67rVpVGJ2KUHxg==",
-      "dev": true,
-      "optional": true
-    },
-    "@types/d3-interpolate": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-1.3.1.tgz",
-      "integrity": "sha512-z8Zmi08XVwe8e62vP6wcA+CNuRhpuUU5XPEfqpG0hRypDE5BWNthQHB1UNWWDB7ojCbGaN4qBdsWp5kWxhT1IQ==",
-      "dev": true,
-      "requires": {
-        "@types/d3-color": "*"
-      }
-    },
-    "@types/d3-path": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-1.0.8.tgz",
-      "integrity": "sha512-AZGHWslq/oApTAHu9+yH/Bnk63y9oFOMROtqPAtxl5uB6qm1x2lueWdVEjsjjV3Qc2+QfuzKIwIR5MvVBakfzA==",
-      "dev": true
-    },
-    "@types/d3-polygon": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/@types/d3-polygon/-/d3-polygon-1.0.7.tgz",
-      "integrity": "sha512-Xuw0eSjQQKs8jTiNbntWH0S+Xp+JyhqxmQ0YAQ3rDu6c3kKMFfgsaGN7Jv5u3zG6yVX/AsLP/Xs/QRjmi9g43Q==",
-      "dev": true,
-      "optional": true
-    },
-    "@types/d3-quadtree": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/@types/d3-quadtree/-/d3-quadtree-1.0.7.tgz",
-      "integrity": "sha512-0ajFawWicfjsaCLh6NzxOyVDYhQAmMFbsiI3MPGLInorauHFEh9/Cl6UHNf+kt/J1jfoxKY/ZJaKAoDpbvde5Q==",
-      "dev": true,
-      "optional": true
-    },
-    "@types/d3-queue": {
-      "version": "3.0.8",
-      "resolved": "https://registry.npmjs.org/@types/d3-queue/-/d3-queue-3.0.8.tgz",
-      "integrity": "sha512-1FWOiI/MYwS5Z1Sa9EvS1Xet3isiVIIX5ozD6iGnwHonGcqL+RcC1eThXN5VfDmAiYt9Me9EWNEv/9J9k9RIKQ==",
-      "dev": true,
-      "optional": true
-    },
-    "@types/d3-random": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@types/d3-random/-/d3-random-1.1.2.tgz",
-      "integrity": "sha512-Jui+Zn28pQw/3EayPKaN4c/PqTvqNbIPjHkgIIFnxne1FdwNjfHtAIsZIBMKlquQNrrMjFzCrlF2gPs3xckqaA==",
-      "dev": true,
-      "optional": true
-    },
-    "@types/d3-request": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/@types/d3-request/-/d3-request-1.0.5.tgz",
-      "integrity": "sha512-X+/c/qXp92o056C5Qbcp7jL27YRHpmIqOchHb/WB7NwFFqkBtAircqO7oKWv2GTtX4LyEqiDF9gqXsV+ldOlIg==",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "@types/d3-dsv": "*"
-      }
-    },
-    "@types/d3-scale": {
-      "version": "1.0.14",
-      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-1.0.14.tgz",
-      "integrity": "sha512-dW6Ii8bH+10klJzVVPPeeQvRpCbX3BO3x9cLTngu/+lXNDbk2uC51aFAA/XhocehZroaG5ajwAFelMFsgpClMg==",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "@types/d3-time": "*"
-      }
-    },
-    "@types/d3-selection": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/@types/d3-selection/-/d3-selection-1.4.1.tgz",
-      "integrity": "sha512-bv8IfFYo/xG6dxri9OwDnK3yCagYPeRIjTlrcdYJSx+FDWlCeBDepIHUpqROmhPtZ53jyna0aUajZRk0I3rXNA==",
-      "dev": true
-    },
-    "@types/d3-shape": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-1.3.1.tgz",
-      "integrity": "sha512-usqdvUvPJ7AJNwpd2drOzRKs1ELie53p2m2GnPKr076/ADM579jVTJ5dPsoZ5E/CMNWk8lvPWYQSvilpp6jjwg==",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "@types/d3-path": "*"
-      }
-    },
-    "@types/d3-time": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-1.0.10.tgz",
-      "integrity": "sha512-aKf62rRQafDQmSiv1NylKhIMmznsjRN+MnXRXTqHoqm0U/UZzVpdrtRnSIfdiLS616OuC1soYeX1dBg2n1u8Xw==",
-      "dev": true
-    },
-    "@types/d3-time-format": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@types/d3-time-format/-/d3-time-format-2.1.1.tgz",
-      "integrity": "sha512-tJSyXta8ZyJ52wDDHA96JEsvkbL6jl7wowGmuf45+fAkj5Y+SQOnz0N7/H68OWmPshPsAaWMQh+GAws44IzH3g==",
-      "dev": true,
-      "optional": true
-    },
-    "@types/d3-timer": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-1.0.9.tgz",
-      "integrity": "sha512-WvfJ3LFxBbWjqRGz9n7GJt08RrTHPJDVsIwwoCMROlqF+iDacYiAFjf9oqnq0mXpb2juA2N/qjKP+MKdal3YNQ==",
-      "dev": true,
-      "optional": true
-    },
-    "@types/d3-transition": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@types/d3-transition/-/d3-transition-1.1.4.tgz",
-      "integrity": "sha512-/vsmKVUIXEyCcIXYAlw7bnYkIs9/J/nZbptRJFKUN3FdXq/dF6j9z9xXzerkyU6TDHLrMrwx9eGwdKyTIy/j9w==",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "@types/d3-selection": "*"
-      }
-    },
-    "@types/d3-voronoi": {
-      "version": "1.1.9",
-      "resolved": "https://registry.npmjs.org/@types/d3-voronoi/-/d3-voronoi-1.1.9.tgz",
-      "integrity": "sha512-DExNQkaHd1F3dFPvGA/Aw2NGyjMln6E9QzsiqOcBgnE+VInYnFBHBBySbZQts6z6xD+5jTfKCP7M4OqMyVjdwQ==",
-      "dev": true,
-      "optional": true
-    },
-    "@types/d3-zoom": {
-      "version": "1.7.4",
-      "resolved": "https://registry.npmjs.org/@types/d3-zoom/-/d3-zoom-1.7.4.tgz",
-      "integrity": "sha512-5jnFo/itYhJeB2khO/lKe730kW/h2EbKMOvY0uNp3+7NdPm4w63DwPEMxifQZ7n902xGYK5DdU67FmToSoy4VA==",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "@types/d3-interpolate": "*",
-        "@types/d3-selection": "*"
-      }
-    },
-    "@types/geojson": {
-      "version": "7946.0.7",
-      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.7.tgz",
-      "integrity": "sha512-wE2v81i4C4Ol09RtsWFAqg3BUitWbHSpSlIo+bNdsCJijO9sjme+zm+73ZMCa/qMC8UEERxzGbvmr1cffo2SiQ==",
-      "dev": true,
-      "optional": true
     },
     "@types/loader-utils": {
       "version": "1.1.3",
@@ -938,12 +573,6 @@
       "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
       "dev": true
     },
-    "asap": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
-      "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY=",
-      "dev": true
-    },
     "asn1": {
       "version": "0.2.4",
       "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
@@ -1056,16 +685,6 @@
       "integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ==",
       "dev": true
     },
-    "axios": {
-      "version": "0.17.1",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.17.1.tgz",
-      "integrity": "sha1-LY4+XQvb1zJ/kbyBT1xXZg+Bgk0=",
-      "dev": true,
-      "requires": {
-        "follow-redirects": "^1.2.5",
-        "is-buffer": "^1.1.5"
-      }
-    },
     "axobject-query": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-2.0.2.tgz",
@@ -1098,41 +717,6 @@
             "esrecurse": "^4.1.0",
             "estraverse": "^4.1.1"
           }
-        }
-      }
-    },
-    "babel-plugin-transform-rename-import": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-rename-import/-/babel-plugin-transform-rename-import-2.3.0.tgz",
-      "integrity": "sha512-dPgJoT57XC0PqSnLgl2FwNvxFrWlspatX2dkk7yjKQj5HHGw071vAcOf+hqW8ClqcBDMvEbm6mevn5yHAD8mlQ==",
-      "dev": true
-    },
-    "babel-polyfill": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/babel-polyfill/-/babel-polyfill-6.26.0.tgz",
-      "integrity": "sha1-N5k3q8Z9eJWXCtxiHyhM2WbPIVM=",
-      "dev": true,
-      "requires": {
-        "babel-runtime": "^6.26.0",
-        "core-js": "^2.5.0",
-        "regenerator-runtime": "^0.10.5"
-      }
-    },
-    "babel-runtime": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
-      "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
-      "dev": true,
-      "requires": {
-        "core-js": "^2.4.0",
-        "regenerator-runtime": "^0.11.0"
-      },
-      "dependencies": {
-        "regenerator-runtime": {
-          "version": "0.11.1",
-          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
-          "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==",
-          "dev": true
         }
       }
     },
@@ -1298,74 +882,6 @@
         }
       }
     },
-    "bootstrap": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-3.4.1.tgz",
-      "integrity": "sha512-yN5oZVmRCwe5aKwzRj6736nSmKDX7pLYwsXiCj/EYmo16hODaBiT4En5btW/jhBF/seV+XMx3aYwukYC3A49DA==",
-      "dev": true
-    },
-    "bootstrap-datepicker": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/bootstrap-datepicker/-/bootstrap-datepicker-1.9.0.tgz",
-      "integrity": "sha512-9rYYbaVOheGYxjOr/+bJCmRPihfy+LkLSg4fIFMT9Od8WwWB/MB50w0JO1eBgKUMbb7PFHQD5uAfI3ArAxZRXA==",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "jquery": ">=1.7.1 <4.0.0"
-      }
-    },
-    "bootstrap-sass": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/bootstrap-sass/-/bootstrap-sass-3.4.1.tgz",
-      "integrity": "sha512-p5rxsK/IyEDQm2CwiHxxUi0MZZtvVFbhWmyMOt4lLkA4bujDA1TGoKT0i1FKIWiugAdP+kK8T5KMDFIKQCLYIA==",
-      "dev": true
-    },
-    "bootstrap-select": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/bootstrap-select/-/bootstrap-select-1.12.2.tgz",
-      "integrity": "sha1-WNCVs/1YSzFEOGb745tv3U5OEqQ=",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "jquery": ">=1.8"
-      }
-    },
-    "bootstrap-slider": {
-      "version": "9.10.0",
-      "resolved": "https://registry.npmjs.org/bootstrap-slider/-/bootstrap-slider-9.10.0.tgz",
-      "integrity": "sha1-EQPWvADPv6jPyaJZmrUYxVZD2j8=",
-      "dev": true,
-      "optional": true
-    },
-    "bootstrap-slider-without-jquery": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/bootstrap-slider-without-jquery/-/bootstrap-slider-without-jquery-10.0.0.tgz",
-      "integrity": "sha512-CB9CrpNVrIytlOoqHtRXhhxFo/jencr1U5cMqPBA0WmMdb13bzjHnXQVNGYde/g5gWW+RWiuT9jTquZuz3VE8A==",
-      "dev": true
-    },
-    "bootstrap-switch": {
-      "version": "3.3.5",
-      "resolved": "https://registry.npmjs.org/bootstrap-switch/-/bootstrap-switch-3.3.5.tgz",
-      "integrity": "sha512-aRwgTPO7QPvTtUxit2ucXgs/P+dp3Y8Qy41XOOqTXZiJvfI6b87+hP+r4B4+3y7bptu0P6KHIyEc4ordEVIVkg==",
-      "dev": true,
-      "optional": true
-    },
-    "bootstrap-touchspin": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/bootstrap-touchspin/-/bootstrap-touchspin-3.1.1.tgz",
-      "integrity": "sha1-l3nerHKq9Xfl52K4USx0fIcdlZc=",
-      "dev": true,
-      "optional": true
-    },
-    "brace": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/brace/-/brace-0.10.0.tgz",
-      "integrity": "sha1-7e9OubCSi6HuX3F//BV3SabdXXY=",
-      "dev": true,
-      "requires": {
-        "w3c-blob": "0.0.1"
-      }
-    },
     "brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -1403,12 +919,6 @@
           }
         }
       }
-    },
-    "breakjs": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/breakjs/-/breakjs-1.0.0.tgz",
-      "integrity": "sha1-7INToGhi60OWLergkHLuZqTNhFk=",
-      "dev": true
     },
     "brorand": {
       "version": "1.1.0",
@@ -1521,15 +1031,6 @@
       "integrity": "sha1-0ygVQE1olpn4Wk6k+odV3ROpYEg=",
       "dev": true
     },
-    "c3": {
-      "version": "0.4.23",
-      "resolved": "https://registry.npmjs.org/c3/-/c3-0.4.23.tgz",
-      "integrity": "sha512-fI6hbx1QoATU0gRQtPWsUGWX+ssXhxGH1ogew32KjVmGHFE4WmfmBkh+RkuHDoeCIoGFon7XTpKcwUZpBGW4mQ==",
-      "dev": true,
-      "requires": {
-        "d3": "~3.5.0"
-      }
-    },
     "cacache": {
       "version": "11.3.2",
       "resolved": "https://registry.npmjs.org/cacache/-/cacache-11.3.2.tgz",
@@ -1627,12 +1128,6 @@
         }
       }
     },
-    "change-emitter": {
-      "version": "0.1.6",
-      "resolved": "https://registry.npmjs.org/change-emitter/-/change-emitter-0.1.6.tgz",
-      "integrity": "sha1-6LL+PX8at9aaMhma/5HqaTFAlRU=",
-      "dev": true
-    },
     "chardet": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
@@ -1711,12 +1206,6 @@
           }
         }
       }
-    },
-    "classnames": {
-      "version": "2.2.6",
-      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.2.6.tgz",
-      "integrity": "sha512-JR/iSQOSt+LQIWwrwEzJ9uk0xfN3mTVYMwt1Ir5mUcSN6pU+V4zQFFaJsclJbPuAUQH+yfWef6tm7l1quW3C8Q==",
-      "dev": true
     },
     "cli-cursor": {
       "version": "2.1.0",
@@ -2104,12 +1593,6 @@
         }
       }
     },
-    "core-js": {
-      "version": "2.6.7",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.7.tgz",
-      "integrity": "sha512-ydmsQxDVH7lDpYoirXft8S83ddKKfdsrsmWhtyj7xafXVLbLhKOyfD7kAi2ueFfeP7m9rNavjW59O3hLLzzC5A==",
-      "dev": true
-    },
     "core-util-is": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
@@ -2152,16 +1635,6 @@
         "sha.js": "^2.4.8"
       }
     },
-    "create-react-context": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/create-react-context/-/create-react-context-0.2.3.tgz",
-      "integrity": "sha512-CQBmD0+QGgTaxDL3OX1IDXYqjkp2It4RIbcb99jS6AEg27Ga+a9G3JtK6SIu0HBwPLZlmwt9F7UwWA4Bn92Rag==",
-      "dev": true,
-      "requires": {
-        "fbjs": "^0.8.0",
-        "gud": "^1.0.0"
-      }
-    },
     "cross-spawn": {
       "version": "6.0.5",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
@@ -2193,12 +1666,6 @@
         "randombytes": "^2.0.0",
         "randomfill": "^1.0.3"
       }
-    },
-    "css-element-queries": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/css-element-queries/-/css-element-queries-1.2.0.tgz",
-      "integrity": "sha512-4gaxpioSFueMcp9yj1TJFCLjfooGv38y6ZdwFUS3GuS+9NIVijdeiExXKwSIHoQDADfpgnaYSTzmJs+bV+Hehg==",
-      "dev": true
     },
     "css-loader": {
       "version": "2.1.1",
@@ -2239,12 +1706,6 @@
       "resolved": "https://registry.npmjs.org/cyclist/-/cyclist-0.2.2.tgz",
       "integrity": "sha1-GzN5LhHpFKL9bW7WRHRkRE5fpkA="
     },
-    "d3": {
-      "version": "3.5.17",
-      "resolved": "https://registry.npmjs.org/d3/-/d3-3.5.17.tgz",
-      "integrity": "sha1-vEZ0gAQ3iyGjYMn8fPUjF5B2L7g=",
-      "dev": true
-    },
     "damerau-levenshtein": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/damerau-levenshtein/-/damerau-levenshtein-1.0.4.tgz",
@@ -2260,73 +1721,11 @@
         "assert-plus": "^1.0.0"
       }
     },
-    "datatables.net": {
-      "version": "1.10.19",
-      "resolved": "https://registry.npmjs.org/datatables.net/-/datatables.net-1.10.19.tgz",
-      "integrity": "sha512-+ljXcI6Pj3PTGy5pesp3E5Dr3x3AV45EZe0o1r0gKENN2gafBKXodVnk2ypKwl2tTmivjxbkiqoWnipTefyBTA==",
-      "dev": true,
-      "requires": {
-        "jquery": ">=1.7"
-      }
-    },
-    "datatables.net-bs": {
-      "version": "1.10.19",
-      "resolved": "https://registry.npmjs.org/datatables.net-bs/-/datatables.net-bs-1.10.19.tgz",
-      "integrity": "sha512-5gxoI2n+duZP06+4xVC2TtH6zcY369/TRKTZ1DdSgDcDUl4OYQsrXCuaLJmbVzna/5Y5lrMmK7CxgvYgIynICA==",
-      "dev": true,
-      "requires": {
-        "datatables.net": "1.10.19",
-        "jquery": ">=1.7"
-      }
-    },
-    "datatables.net-colreorder": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/datatables.net-colreorder/-/datatables.net-colreorder-1.5.1.tgz",
-      "integrity": "sha512-nKV0ZBOdOG+CCrtDZZlTOvhu9NC53pr4rYR8Xhd3KIKipLZohWWdBoOFGMu+VKDvllg2Xj79oS/wicYSiNyteA==",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "datatables.net": "^1.10.15",
-        "jquery": ">=1.7"
-      }
-    },
-    "datatables.net-colreorder-bs": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/datatables.net-colreorder-bs/-/datatables.net-colreorder-bs-1.3.3.tgz",
-      "integrity": "sha1-Op3LCN7r612FQHlZHgbkk615OlM=",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "datatables.net-bs": ">=1.10.9",
-        "datatables.net-colreorder": ">=1.2.0",
-        "jquery": ">=1.7"
-      }
-    },
-    "datatables.net-select": {
-      "version": "1.2.7",
-      "resolved": "https://registry.npmjs.org/datatables.net-select/-/datatables.net-select-1.2.7.tgz",
-      "integrity": "sha512-C3XDi7wpruGjDXV36dc9hN/FrAX9GOFvBZ7+KfKJTBNkGFbbhdzHS91SMeGiwRXPYivAyxfPTcVVndVaO83uBQ==",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "datatables.net": "^1.10.15",
-        "jquery": ">=1.7"
-      }
-    },
     "date-now": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz",
       "integrity": "sha1-6vQ5/U1ISK105cx9vvIAZyueNFs=",
       "dev": true
-    },
-    "debug": {
-      "version": "3.2.6",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
-      "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
-      "dev": true,
-      "requires": {
-        "ms": "^2.1.1"
-      }
     },
     "decamelize": {
       "version": "1.2.0",
@@ -2338,18 +1737,6 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
       "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
-      "dev": true
-    },
-    "deep-diff": {
-      "version": "0.3.4",
-      "resolved": "https://registry.npmjs.org/deep-diff/-/deep-diff-0.3.4.tgz",
-      "integrity": "sha1-qsXDmVIjar5fA3ojSQYLoBsArkg=",
-      "dev": true
-    },
-    "deep-equal": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz",
-      "integrity": "sha1-9dJgKStmDghO/0zbyfCK0yR0SLU=",
       "dev": true
     },
     "deep-is": {
@@ -2448,12 +1835,6 @@
       "integrity": "sha1-8NZtA2cqglyxtzvbP+YjEMjlUrc=",
       "dev": true
     },
-    "diff": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-3.0.1.tgz",
-      "integrity": "sha1-pS2QzAiVaZS+AId7/5cRAGJYLDU=",
-      "dev": true
-    },
     "diffie-hellman": {
       "version": "5.0.3",
       "resolved": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.3.tgz",
@@ -2482,30 +1863,11 @@
         "esutils": "^2.0.2"
       }
     },
-    "dom-helpers": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-3.4.0.tgz",
-      "integrity": "sha512-LnuPJ+dwqKDIyotW1VzmOZ5TONUN7CwkCR5hrgawTUbkBGYdeoNLZo6nNfGkCrjtE1nXXaj7iMMpDa8/d9WoIA==",
-      "dev": true,
-      "requires": {
-        "@babel/runtime": "^7.1.2"
-      }
-    },
     "domain-browser": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.2.0.tgz",
       "integrity": "sha512-jnjyiM6eRyZl2H+W8Q/zLMA481hzi0eszAaBUzIVnmYVDBbnLxVNnfu1HgEBvCbL+71FrxMl3E6lpKH7Ge3OXA==",
       "dev": true
-    },
-    "drmonty-datatables-colvis": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/drmonty-datatables-colvis/-/drmonty-datatables-colvis-1.1.2.tgz",
-      "integrity": "sha1-lque37SGQ8wu3aP4e4iTPN7oEnw=",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "jquery": ">=1.7.0"
-      }
     },
     "duplexer": {
       "version": "0.1.1",
@@ -2578,15 +1940,6 @@
       "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k=",
       "dev": true
     },
-    "encoding": {
-      "version": "0.1.12",
-      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
-      "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
-      "dev": true,
-      "requires": {
-        "iconv-lite": "~0.4.13"
-      }
-    },
     "end-of-stream": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
@@ -2604,19 +1957,6 @@
         "graceful-fs": "^4.1.2",
         "memory-fs": "^0.4.0",
         "tapable": "^1.0.0"
-      }
-    },
-    "eonasdan-bootstrap-datetimepicker": {
-      "version": "4.17.47",
-      "resolved": "https://registry.npmjs.org/eonasdan-bootstrap-datetimepicker/-/eonasdan-bootstrap-datetimepicker-4.17.47.tgz",
-      "integrity": "sha1-ekmXAEQGUnbnll79Fvgic1IZ5zU=",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "bootstrap": "^3.3",
-        "jquery": "^1.8.3 || ^2.0 || ^3.0",
-        "moment": "^2.10",
-        "moment-timezone": "^0.4.0"
       }
     },
     "errno": {
@@ -2661,12 +2001,6 @@
         "is-date-object": "^1.0.1",
         "is-symbol": "^1.0.2"
       }
-    },
-    "es6-error": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/es6-error/-/es6-error-4.1.1.tgz",
-      "integrity": "sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==",
-      "dev": true
     },
     "escape-html": {
       "version": "1.0.3",
@@ -2788,12 +2122,6 @@
       "requires": {
         "eslint-config-standard-jsx": "^5.0.0"
       }
-    },
-    "eslint-import-resolver-alias": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/eslint-import-resolver-alias/-/eslint-import-resolver-alias-1.1.2.tgz",
-      "integrity": "sha512-WdviM1Eu834zsfjHtcGHtGfcu+F30Od3V7I9Fi57uhBEwPkjDcii7/yW8jAT+gOhn4P/vOxxNAXbFAKsrrc15w==",
-      "dev": true
     },
     "eslint-import-resolver-node": {
       "version": "0.3.2",
@@ -3416,29 +2744,6 @@
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
       "dev": true
     },
-    "fbjs": {
-      "version": "0.8.17",
-      "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.17.tgz",
-      "integrity": "sha1-xNWY6taUkRJlPWWIsBpc3Nn5D90=",
-      "dev": true,
-      "requires": {
-        "core-js": "^1.0.0",
-        "isomorphic-fetch": "^2.1.1",
-        "loose-envify": "^1.0.0",
-        "object-assign": "^4.1.0",
-        "promise": "^7.1.1",
-        "setimmediate": "^1.0.5",
-        "ua-parser-js": "^0.7.18"
-      },
-      "dependencies": {
-        "core-js": {
-          "version": "1.2.7",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
-          "integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY=",
-          "dev": true
-        }
-      }
-    },
     "figgy-pudding": {
       "version": "3.5.1",
       "resolved": "https://registry.npmjs.org/figgy-pudding/-/figgy-pudding-3.5.1.tgz",
@@ -3593,28 +2898,6 @@
         "readable-stream": "^2.3.6"
       }
     },
-    "follow-redirects": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.7.0.tgz",
-      "integrity": "sha512-m/pZQy4Gj287eNy94nivy5wchN3Kp+Q5WgUPNy5lJSZ3sgkVKSYV/ZChMAQVIgx1SqfZ2zBZtPA2YlXIWxxJOQ==",
-      "dev": true,
-      "requires": {
-        "debug": "^3.2.6"
-      }
-    },
-    "font-awesome": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/font-awesome/-/font-awesome-4.7.0.tgz",
-      "integrity": "sha1-j6jPBBGhoxr9B7BtKQK7n8gVoTM=",
-      "dev": true
-    },
-    "font-awesome-sass": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/font-awesome-sass/-/font-awesome-sass-4.7.0.tgz",
-      "integrity": "sha1-TtppPpFQCc4Asijglk3F7Km8NOE=",
-      "dev": true,
-      "optional": true
-    },
     "for-in": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
@@ -3734,12 +3017,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -3754,17 +3039,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -3881,7 +3169,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -3893,6 +3182,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -3907,6 +3197,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -3914,12 +3205,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -3938,6 +3231,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -4018,7 +3312,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -4030,6 +3325,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -4151,6 +3447,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -4344,12 +3641,6 @@
         "assert-plus": "^1.0.0"
       }
     },
-    "gitdiff-parser": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/gitdiff-parser/-/gitdiff-parser-0.1.2.tgz",
-      "integrity": "sha512-glDM6E1AwLYYTOPyI0CqamNEUSuwwAkmwULWpE2sHMpMZNzGJwErt7+eV+yIZcsbDza0pVSlwlBHFWbTf2Wu7A==",
-      "dev": true
-    },
     "glob": {
       "version": "7.1.3",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
@@ -4445,23 +3736,10 @@
         "minimatch": "~3.0.2"
       }
     },
-    "google-code-prettify": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/google-code-prettify/-/google-code-prettify-1.0.5.tgz",
-      "integrity": "sha1-n0d/Ik2/piNy5e+AOn4VdBBAAIQ=",
-      "dev": true,
-      "optional": true
-    },
     "graceful-fs": {
       "version": "4.1.15",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.15.tgz",
       "integrity": "sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA=="
-    },
-    "gud": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/gud/-/gud-1.0.0.tgz",
-      "integrity": "sha512-zGEOVKFM5sVPPrYs7J5/hYEw2Pof8KCyOwyhG8sAF26mCAeUFAcYPu1mwB7hhpIP29zOIBaDqwuHdLp0jvZXjw==",
-      "dev": true
     },
     "gzip-size": {
       "version": "5.0.0",
@@ -4603,12 +3881,6 @@
         "minimalistic-assert": "^1.0.0",
         "minimalistic-crypto-utils": "^1.0.1"
       }
-    },
-    "hoist-non-react-statics": {
-      "version": "2.5.5",
-      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-2.5.5.tgz",
-      "integrity": "sha512-rqcy4pJo55FTTLWt+bU8ukscqHeE/e9KWvsOW2b/a3afxQZhwkQdT1rPPCJ0rYXdj4vNcasY8zHTH+jF/qStxw==",
-      "dev": true
     },
     "homedir-polyfill": {
       "version": "1.0.3",
@@ -4816,25 +4088,10 @@
       "integrity": "sha512-mT34yGKMNceBQUoVn7iCDKDntA7SC6gycMAWzGx1z/CMCTV7b2AAtXlo3nRyHZ1FelRkQbQjprHSYGwzLtkVbw==",
       "dev": true
     },
-    "invariant": {
-      "version": "2.2.4",
-      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
-      "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
-      "dev": true,
-      "requires": {
-        "loose-envify": "^1.0.0"
-      }
-    },
     "invert-kv": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
       "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY=",
-      "dev": true
-    },
-    "ipaddr.js": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.2.0.tgz",
-      "integrity": "sha1-irpJyRknmVhb3WQ+DMtQ6K53e6Q=",
       "dev": true
     },
     "is-accessor-descriptor": {
@@ -5057,16 +4314,6 @@
       "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
       "dev": true
     },
-    "isomorphic-fetch": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
-      "integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=",
-      "dev": true,
-      "requires": {
-        "node-fetch": "^1.0.1",
-        "whatwg-fetch": ">=0.10.0"
-      }
-    },
     "isstream": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
@@ -5077,40 +4324,6 @@
       "version": "21.2.0",
       "resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-21.2.0.tgz",
       "integrity": "sha512-5IZ7sY9dBAYSV+YjQ0Ovb540Ku7AO9Z5o2Cg789xj167iQuZ2cG+z0f3Uct6WeYLbU6aQiM2pCs7sZ+4dotydw==",
-      "dev": true
-    },
-    "jquery": {
-      "version": "2.2.4",
-      "resolved": "https://registry.npmjs.org/jquery/-/jquery-2.2.4.tgz",
-      "integrity": "sha1-LInWiJterFIqfuoywUUhVZxsvwI=",
-      "dev": true
-    },
-    "jquery-flot": {
-      "version": "0.8.3",
-      "resolved": "https://registry.npmjs.org/jquery-flot/-/jquery-flot-0.8.3.tgz",
-      "integrity": "sha1-onOs9D8TGQ9ueHAYae4kv+8Swio=",
-      "dev": true
-    },
-    "jquery-match-height": {
-      "version": "0.7.2",
-      "resolved": "https://registry.npmjs.org/jquery-match-height/-/jquery-match-height-0.7.2.tgz",
-      "integrity": "sha1-+NnzulMU2qsQnPB0CGdL4gS+Xw4=",
-      "dev": true,
-      "optional": true
-    },
-    "jquery-ujs": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/jquery-ujs/-/jquery-ujs-1.2.2.tgz",
-      "integrity": "sha1-ao7xAg5rbdo4W5CkvdwSjCHFY5c=",
-      "dev": true,
-      "requires": {
-        "jquery": ">=1.8.0"
-      }
-    },
-    "jquery.cookie": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/jquery.cookie/-/jquery.cookie-1.4.1.tgz",
-      "integrity": "sha1-1j3OIJ6raR/mMxbbCMqeR+D5OFs=",
       "dev": true
     },
     "js-base64": {
@@ -5204,12 +4417,6 @@
         "verror": "1.10.0"
       }
     },
-    "jstz": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/jstz/-/jstz-1.0.11.tgz",
-      "integrity": "sha512-TII4P76PQfjffpzl3mk6SyqOr0sUqK+zWm1GLv505j9vXNfAPxKC5uWa/hwcPJ0mZvuP3u2xjm3OGuKRlEw/Yw==",
-      "dev": true
-    },
     "jsx-ast-utils": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-2.0.1.tgz",
@@ -5218,12 +4425,6 @@
       "requires": {
         "array-includes": "^3.0.3"
       }
-    },
-    "keycode": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/keycode/-/keycode-2.2.0.tgz",
-      "integrity": "sha1-PQr1bce4uOXLqNCpfxByBO7CKwQ=",
-      "dev": true
     },
     "kind-of": {
       "version": "6.0.2",
@@ -5239,12 +4440,6 @@
       "requires": {
         "invert-kv": "^1.0.0"
       }
-    },
-    "leven": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/leven/-/leven-2.1.0.tgz",
-      "integrity": "sha1-wuep93IJTe6dNCAq6KzORoeHVYA=",
-      "dev": true
     },
     "levn": {
       "version": "0.3.0",
@@ -5308,12 +4503,6 @@
       "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
       "dev": true
     },
-    "lodash-es": {
-      "version": "4.17.11",
-      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.11.tgz",
-      "integrity": "sha512-DHb1ub+rMjjrxqlB3H56/6MXtm1lSksDp2rA2cNWjG8mlDUYFhUj3Di2Zn5IwSU87xLv8tNIQ7sSwE/YOX/D/Q==",
-      "dev": true
-    },
     "lodash.assign": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-4.2.0.tgz",
@@ -5324,30 +4513,6 @@
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
       "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8=",
-      "dev": true
-    },
-    "lodash.debounce": {
-      "version": "4.0.8",
-      "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
-      "integrity": "sha1-gteb/zCmfEAF/9XiUVMArZyk168=",
-      "dev": true
-    },
-    "lodash.escape": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-4.0.1.tgz",
-      "integrity": "sha1-yQRGkMIeBClL6qUXcS/e0fqI3pg=",
-      "dev": true
-    },
-    "lodash.findlastindex": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/lodash.findlastindex/-/lodash.findlastindex-4.6.0.tgz",
-      "integrity": "sha1-uDdawPAum5Jjdc343D6oFKv5xqw=",
-      "dev": true
-    },
-    "lodash.mapvalues": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/lodash.mapvalues/-/lodash.mapvalues-4.6.0.tgz",
-      "integrity": "sha1-G6+lAF3p3W9PJmaMMMo3IwzJaJw=",
       "dev": true
     },
     "lodash.mergewith": {
@@ -5758,22 +4923,6 @@
         "minimist": "0.0.8"
       }
     },
-    "moment": {
-      "version": "2.24.0",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.24.0.tgz",
-      "integrity": "sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg==",
-      "dev": true
-    },
-    "moment-timezone": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.4.1.tgz",
-      "integrity": "sha1-gfWYw61eIs2teWtn7NjYjQ9bqgY=",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "moment": ">= 2.6.0"
-      }
-    },
     "move-concurrently": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/move-concurrently/-/move-concurrently-1.0.1.tgz",
@@ -5792,15 +4941,6 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
       "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
       "dev": true
-    },
-    "multiselect": {
-      "version": "0.9.12",
-      "resolved": "https://registry.npmjs.org/multiselect/-/multiselect-0.9.12.tgz",
-      "integrity": "sha1-0VU26YbdagApsWDWYTvO34Hkx+0=",
-      "dev": true,
-      "requires": {
-        "jquery": ">= 1.7.1"
-      }
     },
     "mute-stream": {
       "version": "0.0.7",
@@ -5856,16 +4996,6 @@
       "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
       "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
       "dev": true
-    },
-    "node-fetch": {
-      "version": "1.7.3",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
-      "integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
-      "dev": true,
-      "requires": {
-        "encoding": "^0.1.11",
-        "is-stream": "^1.0.1"
-      }
     },
     "node-gyp": {
       "version": "3.8.0",
@@ -6087,12 +5217,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
       "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-      "dev": true
-    },
-    "number_helpers": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/number_helpers/-/number_helpers-0.1.1.tgz",
-      "integrity": "sha1-GN7I2CYw0Fx8XfNdSThhfHrLrwU=",
       "dev": true
     },
     "oauth-sign": {
@@ -6426,94 +5550,6 @@
         }
       }
     },
-    "patternfly": {
-      "version": "3.59.1",
-      "resolved": "https://registry.npmjs.org/patternfly/-/patternfly-3.59.1.tgz",
-      "integrity": "sha512-0Q/P58yaxcQXwnXo/OssiXaZmuX0g9QvWdpsYHyml4ihqnN2lL/yGdadFarA6UAQb//15XtNjKHZocoJXCkWYg==",
-      "dev": true,
-      "requires": {
-        "@types/c3": "^0.6.0",
-        "bootstrap": "~3.4.0",
-        "bootstrap-datepicker": "^1.7.1",
-        "bootstrap-sass": "^3.4.0",
-        "bootstrap-select": "1.12.2",
-        "bootstrap-slider": "^9.9.0",
-        "bootstrap-switch": "~3.3.4",
-        "bootstrap-touchspin": "~3.1.1",
-        "c3": "~0.4.11",
-        "d3": "~3.5.17",
-        "datatables.net": "^1.10.15",
-        "datatables.net-colreorder": "^1.4.1",
-        "datatables.net-colreorder-bs": "~1.3.2",
-        "datatables.net-select": "~1.2.0",
-        "drmonty-datatables-colvis": "~1.1.2",
-        "eonasdan-bootstrap-datetimepicker": "^4.17.47",
-        "font-awesome": "^4.7.0",
-        "font-awesome-sass": "^4.7.0",
-        "google-code-prettify": "~1.0.5",
-        "jquery": "~3.2.1",
-        "jquery-match-height": "^0.7.2",
-        "moment": "^2.19.1",
-        "moment-timezone": "^0.4.1",
-        "patternfly-bootstrap-combobox": "~1.1.7",
-        "patternfly-bootstrap-treeview": "~2.1.0"
-      },
-      "dependencies": {
-        "jquery": {
-          "version": "3.2.1",
-          "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.2.1.tgz",
-          "integrity": "sha1-XE2d5lKvbNCncBVKYxu6ErAVx4c=",
-          "dev": true
-        }
-      }
-    },
-    "patternfly-bootstrap-combobox": {
-      "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/patternfly-bootstrap-combobox/-/patternfly-bootstrap-combobox-1.1.7.tgz",
-      "integrity": "sha1-al48zRFwwhs8S0qhaKdBPh3btuE=",
-      "dev": true,
-      "optional": true
-    },
-    "patternfly-bootstrap-treeview": {
-      "version": "2.1.8",
-      "resolved": "https://registry.npmjs.org/patternfly-bootstrap-treeview/-/patternfly-bootstrap-treeview-2.1.8.tgz",
-      "integrity": "sha512-Z3v+zJ0AEhMiySyj7qgUs4yGM8afJwjUUWgwSosWI9xpMsyJV+B+I+GzgRoGiukzh14EOl3EiX4qqMBC+nwqXQ==",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "bootstrap": "3.4.x",
-        "jquery": ">= 2.1.x"
-      }
-    },
-    "patternfly-react": {
-      "version": "2.34.3",
-      "resolved": "https://registry.npmjs.org/patternfly-react/-/patternfly-react-2.34.3.tgz",
-      "integrity": "sha512-5bdIBHpo1bdO3gsYC1tbmxeXX/NXe5ghBen3MCFeumUDZGtKmaoN5NOY+uGL6LtkWTCTA7heKXJxfFOuk/IXrA==",
-      "dev": true,
-      "requires": {
-        "bootstrap-slider-without-jquery": "^10.0.0",
-        "breakjs": "^1.0.0",
-        "classnames": "^2.2.5",
-        "css-element-queries": "^1.0.1",
-        "lodash": "^4.17.11",
-        "patternfly": "^3.58.0",
-        "react-bootstrap": "^0.32.1",
-        "react-bootstrap-switch": "^15.5.3",
-        "react-bootstrap-typeahead": "^3.4.1",
-        "react-c3js": "^0.1.20",
-        "react-click-outside": "^3.0.1",
-        "react-collapse": "^4.0.3",
-        "react-debounce-input": "^3.2.0",
-        "react-ellipsis-with-tooltip": "^1.0.8",
-        "react-fontawesome": "^1.6.1",
-        "react-motion": "^0.5.2",
-        "reactabular-table": "^8.14.0",
-        "recompose": "^0.26.0",
-        "sortabular": "^1.5.1",
-        "table-resolver": "^3.2.0",
-        "uuid": "^3.3.2"
-      }
-    },
     "pbkdf2": {
       "version": "3.0.17",
       "resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.0.17.tgz",
@@ -6526,12 +5562,6 @@
         "safe-buffer": "^5.0.1",
         "sha.js": "^2.4.8"
       }
-    },
-    "performance-now": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-0.2.0.tgz",
-      "integrity": "sha1-M+8wxcd9TqIcWlOGnZG1bY8lVeU=",
-      "dev": true
     },
     "pify": {
       "version": "4.0.1",
@@ -6562,12 +5592,6 @@
       "requires": {
         "find-up": "^3.0.0"
       }
-    },
-    "popper.js": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/popper.js/-/popper.js-1.15.0.tgz",
-      "integrity": "sha512-w010cY1oCUmI+9KwwlWki+r5jxKfTFDVoadl7MSrIujHU5MJ5OR6HTDj6Xo8aoR/QsA56x8jKjA59qGH4ELtrA==",
-      "dev": true
     },
     "posix-character-classes": {
       "version": "0.1.1",
@@ -6672,15 +5696,6 @@
       "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
       "dev": true
     },
-    "promise": {
-      "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
-      "integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
-      "dev": true,
-      "requires": {
-        "asap": "~2.0.3"
-      }
-    },
     "promise-inflight": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/promise-inflight/-/promise-inflight-1.0.1.tgz",
@@ -6695,16 +5710,6 @@
         "loose-envify": "^1.4.0",
         "object-assign": "^4.1.1",
         "react-is": "^16.8.1"
-      }
-    },
-    "prop-types-extra": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/prop-types-extra/-/prop-types-extra-1.1.0.tgz",
-      "integrity": "sha512-QFyuDxvMipmIVKD2TwxLVPzMnO4e5oOf1vr3tJIomL8E7d0lr6phTHd5nkPhFIzTD1idBLLEPeylL9g+rrTzRg==",
-      "dev": true,
-      "requires": {
-        "react-is": "^16.3.2",
-        "warning": "^3.0.0"
       }
     },
     "proxy-addr": {
@@ -6811,23 +5816,6 @@
       "integrity": "sha1-nsYfeQSYdXB9aUFFlv2Qek1xHnM=",
       "dev": true
     },
-    "raf": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/raf/-/raf-3.4.1.tgz",
-      "integrity": "sha512-Sq4CW4QhwOHE8ucn6J34MqtZCeWFP2aQSmrlroYgqAV1PjStIhJXxYuTgUIfkEk7zTLjmIjLmU5q+fbD1NnOJA==",
-      "dev": true,
-      "requires": {
-        "performance-now": "^2.1.0"
-      },
-      "dependencies": {
-        "performance-now": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
-          "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
-          "dev": true
-        }
-      }
-    },
     "randombytes": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
@@ -6876,315 +5864,11 @@
         }
       }
     },
-    "react": {
-      "version": "16.8.6",
-      "resolved": "https://registry.npmjs.org/react/-/react-16.8.6.tgz",
-      "integrity": "sha512-pC0uMkhLaHm11ZSJULfOBqV4tIZkx87ZLvbbQYunNixAAvjnC+snJCg0XQXn9VIsttVsbZP/H/ewzgsd5fxKXw==",
-      "dev": true,
-      "requires": {
-        "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1",
-        "prop-types": "^15.6.2",
-        "scheduler": "^0.13.6"
-      }
-    },
-    "react-bootstrap": {
-      "version": "0.32.1",
-      "resolved": "https://registry.npmjs.org/react-bootstrap/-/react-bootstrap-0.32.1.tgz",
-      "integrity": "sha512-RbfzKUbsukWsToWqGHfCCyMFq9QQI0TznutdyxyJw6dih2NvIne25Mrssg8LZsprqtPpyQi8bN0L0Fx3fUsL8Q==",
-      "dev": true,
-      "requires": {
-        "babel-runtime": "^6.11.6",
-        "classnames": "^2.2.5",
-        "dom-helpers": "^3.2.0",
-        "invariant": "^2.2.1",
-        "keycode": "^2.1.2",
-        "prop-types": "^15.5.10",
-        "prop-types-extra": "^1.0.1",
-        "react-overlays": "^0.8.0",
-        "react-prop-types": "^0.4.0",
-        "react-transition-group": "^2.0.0",
-        "uncontrollable": "^4.1.0",
-        "warning": "^3.0.0"
-      }
-    },
-    "react-bootstrap-switch": {
-      "version": "15.5.3",
-      "resolved": "https://registry.npmjs.org/react-bootstrap-switch/-/react-bootstrap-switch-15.5.3.tgz",
-      "integrity": "sha1-lyh3kdTsDRiS0UJULn5SSAArElE=",
-      "dev": true
-    },
-    "react-bootstrap-typeahead": {
-      "version": "3.4.3",
-      "resolved": "https://registry.npmjs.org/react-bootstrap-typeahead/-/react-bootstrap-typeahead-3.4.3.tgz",
-      "integrity": "sha512-/F37uKRWOL1IIo4EXCpL/1juHIG6Dzwl/gJlNJlqQGZMWMc/UNjB3DGg3loh3Gqfs4YHBgCu5SxhZWwgtLyRew==",
-      "dev": true,
-      "requires": {
-        "classnames": "^2.2.0",
-        "create-react-context": "^0.2.3",
-        "escape-string-regexp": "^1.0.5",
-        "invariant": "^2.2.1",
-        "lodash": "^4.17.2",
-        "prop-types": "^15.5.8",
-        "prop-types-extra": "^1.0.1",
-        "react-overlays": "^0.8.1",
-        "react-popper": "^1.0.0",
-        "warning": "^4.0.1"
-      },
-      "dependencies": {
-        "warning": {
-          "version": "4.0.3",
-          "resolved": "https://registry.npmjs.org/warning/-/warning-4.0.3.tgz",
-          "integrity": "sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==",
-          "dev": true,
-          "requires": {
-            "loose-envify": "^1.0.0"
-          }
-        }
-      }
-    },
-    "react-c3js": {
-      "version": "0.1.20",
-      "resolved": "https://registry.npmjs.org/react-c3js/-/react-c3js-0.1.20.tgz",
-      "integrity": "sha512-+jtEKJj6bFfD0pj3Vx0dDexpK3uGnZ/kLeJiuXYLBdHppx4tzpwAfMBDlQYQ5m4dqDi7jaovFaL2GX8vZRi+Gw==",
-      "dev": true,
-      "requires": {
-        "c3": "^0.4.11"
-      }
-    },
-    "react-click-outside": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/react-click-outside/-/react-click-outside-3.0.1.tgz",
-      "integrity": "sha512-d0KWFvBt+esoZUF15rL2UBB7jkeAqLU8L/Ny35oLK6fW6mIbOv/ChD+ExF4sR9PD26kVx+9hNfD0FTIqRZEyRQ==",
-      "dev": true,
-      "requires": {
-        "hoist-non-react-statics": "^2.1.1"
-      }
-    },
-    "react-collapse": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/react-collapse/-/react-collapse-4.0.3.tgz",
-      "integrity": "sha512-OO4NhtEqFtz+1ma31J1B7+ezdRnzHCZiTGSSd/Pxoks9hxrZYhzFEddeYt05A/1477xTtdrwo7xEa2FLJyWGCQ==",
-      "dev": true,
-      "requires": {
-        "prop-types": "^15.5.8"
-      }
-    },
-    "react-debounce-input": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/react-debounce-input/-/react-debounce-input-3.2.0.tgz",
-      "integrity": "sha1-aXjGBh2Jj1SfQEF/sNLrvs9Qqqo=",
-      "dev": true,
-      "requires": {
-        "lodash.debounce": "^4",
-        "prop-types": "^15"
-      }
-    },
-    "react-diff-view": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/react-diff-view/-/react-diff-view-1.8.1.tgz",
-      "integrity": "sha512-+soJL85Xnsak/VOdxSgiDKhhaFiOkckiswwrXdiWVCxV3LP9POyJR4AqGVFGdkntJ3YT63mtwTYuunFeId+XSA==",
-      "dev": true,
-      "requires": {
-        "classnames": "^2.2.6",
-        "gitdiff-parser": "^0.1.2",
-        "leven": "^2.1.0",
-        "lodash.escape": "^4.0.1",
-        "lodash.findlastindex": "^4.6.0",
-        "lodash.mapvalues": "^4.6.0",
-        "warning": "^4.0.1"
-      },
-      "dependencies": {
-        "warning": {
-          "version": "4.0.3",
-          "resolved": "https://registry.npmjs.org/warning/-/warning-4.0.3.tgz",
-          "integrity": "sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==",
-          "dev": true,
-          "requires": {
-            "loose-envify": "^1.0.0"
-          }
-        }
-      }
-    },
-    "react-dom": {
-      "version": "16.8.6",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.8.6.tgz",
-      "integrity": "sha512-1nL7PIq9LTL3fthPqwkvr2zY7phIPjYrT0jp4HjyEQrEROnw4dG41VVwi/wfoCneoleqrNX7iAD+pXebJZwrwA==",
-      "dev": true,
-      "requires": {
-        "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1",
-        "prop-types": "^15.6.2",
-        "scheduler": "^0.13.6"
-      }
-    },
-    "react-ellipsis-with-tooltip": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/react-ellipsis-with-tooltip/-/react-ellipsis-with-tooltip-1.0.8.tgz",
-      "integrity": "sha512-GdEYrrvS/iPYVAufShdJz8gtwG5kZNxlBh1Kb/LjCwYgNwGmRlCbVEmXS///bHrbhXoSxnzYbymGHFyYKR4Q6A==",
-      "dev": true,
-      "requires": {
-        "uuid": "^3.1.0"
-      }
-    },
-    "react-fontawesome": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/react-fontawesome/-/react-fontawesome-1.6.1.tgz",
-      "integrity": "sha1-7dzhfn3HMaoJ/UoYZoimF5OhbFw=",
-      "dev": true,
-      "requires": {
-        "prop-types": "^15.5.6"
-      }
-    },
     "react-is": {
       "version": "16.8.4",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.8.4.tgz",
       "integrity": "sha512-PVadd+WaUDOAciICm/J1waJaSvgq+4rHE/K70j0PFqKhkTBsPv/82UGQJNXAngz1fOQLLxI6z1sEDmJDQhCTAA==",
       "dev": true
-    },
-    "react-lifecycles-compat": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
-      "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==",
-      "dev": true
-    },
-    "react-motion": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/react-motion/-/react-motion-0.5.2.tgz",
-      "integrity": "sha512-9q3YAvHoUiWlP3cK0v+w1N5Z23HXMj4IF4YuvjvWegWqNPfLXsOBE/V7UvQGpXxHFKRQQcNcVQE31g9SB/6qgQ==",
-      "dev": true,
-      "requires": {
-        "performance-now": "^0.2.0",
-        "prop-types": "^15.5.8",
-        "raf": "^3.1.0"
-      }
-    },
-    "react-numeric-input": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/react-numeric-input/-/react-numeric-input-2.2.3.tgz",
-      "integrity": "sha1-S/WRjD6v7YUagN8euZLZQQArtVI=",
-      "dev": true
-    },
-    "react-onclickoutside": {
-      "version": "6.8.0",
-      "resolved": "https://registry.npmjs.org/react-onclickoutside/-/react-onclickoutside-6.8.0.tgz",
-      "integrity": "sha512-5Q4Rn7QLEoh7WIe66KFvYIpWJ49GeHoygP1/EtJyZjXKgrWH19Tf0Ty3lWyQzrEEDyLOwUvvmBFSE3dcDdvagA==",
-      "dev": true
-    },
-    "react-overlays": {
-      "version": "0.8.3",
-      "resolved": "https://registry.npmjs.org/react-overlays/-/react-overlays-0.8.3.tgz",
-      "integrity": "sha512-h6GT3jgy90PgctleP39Yu3eK1v9vaJAW73GOA/UbN9dJ7aAN4BTZD6793eI1D5U+ukMk17qiqN/wl3diK1Z5LA==",
-      "dev": true,
-      "requires": {
-        "classnames": "^2.2.5",
-        "dom-helpers": "^3.2.1",
-        "prop-types": "^15.5.10",
-        "prop-types-extra": "^1.0.1",
-        "react-transition-group": "^2.2.0",
-        "warning": "^3.0.0"
-      }
-    },
-    "react-password-strength": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/react-password-strength/-/react-password-strength-2.4.0.tgz",
-      "integrity": "sha512-8ksh5zfF4uXRxJDGgleABu0dS5hN+mQSvzxLpVWEPVwWMxKikLEVUnB0mrbnBHul7mbjVD9QTjzQ78/wm5bewQ==",
-      "dev": true,
-      "requires": {
-        "prop-types": "^15.6.0",
-        "zxcvbn": "^4.3.0"
-      }
-    },
-    "react-popper": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/react-popper/-/react-popper-1.3.3.tgz",
-      "integrity": "sha512-ynMZBPkXONPc5K4P5yFWgZx5JGAUIP3pGGLNs58cfAPgK67olx7fmLp+AdpZ0+GoQ+ieFDa/z4cdV6u7sioH6w==",
-      "dev": true,
-      "requires": {
-        "@babel/runtime": "^7.1.2",
-        "create-react-context": "<=0.2.2",
-        "popper.js": "^1.14.4",
-        "prop-types": "^15.6.1",
-        "typed-styles": "^0.0.7",
-        "warning": "^4.0.2"
-      },
-      "dependencies": {
-        "create-react-context": {
-          "version": "0.2.2",
-          "resolved": "https://registry.npmjs.org/create-react-context/-/create-react-context-0.2.2.tgz",
-          "integrity": "sha512-KkpaLARMhsTsgp0d2NA/R94F/eDLbhXERdIq3LvX2biCAXcDvHYoOqHfWCHf1+OLj+HKBotLG3KqaOOf+C1C+A==",
-          "dev": true,
-          "requires": {
-            "fbjs": "^0.8.0",
-            "gud": "^1.0.0"
-          }
-        },
-        "warning": {
-          "version": "4.0.3",
-          "resolved": "https://registry.npmjs.org/warning/-/warning-4.0.3.tgz",
-          "integrity": "sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==",
-          "dev": true,
-          "requires": {
-            "loose-envify": "^1.0.0"
-          }
-        }
-      }
-    },
-    "react-prop-types": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/react-prop-types/-/react-prop-types-0.4.0.tgz",
-      "integrity": "sha1-+ZsL+0AGkpya8gUefBQUpcdbk9A=",
-      "dev": true,
-      "requires": {
-        "warning": "^3.0.0"
-      }
-    },
-    "react-redux": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-5.1.1.tgz",
-      "integrity": "sha512-LE7Ned+cv5qe7tMV5BPYkGQ5Lpg8gzgItK07c67yHvJ8t0iaD9kPFPAli/mYkiyJYrs2pJgExR2ZgsGqlrOApg==",
-      "dev": true,
-      "requires": {
-        "@babel/runtime": "^7.1.2",
-        "hoist-non-react-statics": "^3.1.0",
-        "invariant": "^2.2.4",
-        "loose-envify": "^1.1.0",
-        "prop-types": "^15.6.1",
-        "react-is": "^16.6.0",
-        "react-lifecycles-compat": "^3.0.0"
-      },
-      "dependencies": {
-        "hoist-non-react-statics": {
-          "version": "3.3.0",
-          "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.0.tgz",
-          "integrity": "sha512-0XsbTXxgiaCDYDIWFcwkmerZPSwywfUqYmwT4jzewKTQSWoE6FCMoUVOeBJWK3E/CrWbxRG3m5GzY4lnIwGRBA==",
-          "dev": true,
-          "requires": {
-            "react-is": "^16.7.0"
-          }
-        }
-      }
-    },
-    "react-transition-group": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-2.9.0.tgz",
-      "integrity": "sha512-+HzNTCHpeQyl4MJ/bdE0u6XRMe9+XG/+aL4mCxVN4DnPBQ0/5bfHWPDuOZUzYdMj94daZaZdCCc1Dzt9R/xSSg==",
-      "dev": true,
-      "requires": {
-        "dom-helpers": "^3.4.0",
-        "loose-envify": "^1.4.0",
-        "prop-types": "^15.6.2",
-        "react-lifecycles-compat": "^3.0.4"
-      }
-    },
-    "reactabular-table": {
-      "version": "8.14.0",
-      "resolved": "https://registry.npmjs.org/reactabular-table/-/reactabular-table-8.14.0.tgz",
-      "integrity": "sha512-F3qOa7yJCi1hnxsESmo2QBWVl1RQfUfZhMhpG81zOxDQKsk/nsXlq/5aBtQ17NadYI6PDdMNourNs+255GpmFQ==",
-      "dev": true,
-      "requires": {
-        "classnames": "^2.2.5"
-      }
     },
     "read-pkg": {
       "version": "2.0.0",
@@ -7294,18 +5978,6 @@
         "readable-stream": "^2.0.2"
       }
     },
-    "recompose": {
-      "version": "0.26.0",
-      "resolved": "https://registry.npmjs.org/recompose/-/recompose-0.26.0.tgz",
-      "integrity": "sha512-KwOu6ztO0mN5vy3+zDcc45lgnaUoaQse/a5yLVqtzTK13czSWnFGmXbQVmnoMgDkI5POd1EwIKSbjU1V7xdZog==",
-      "dev": true,
-      "requires": {
-        "change-emitter": "^0.1.2",
-        "fbjs": "^0.8.1",
-        "hoist-non-react-statics": "^2.3.1",
-        "symbol-observable": "^1.0.4"
-      }
-    },
     "redent": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
@@ -7315,61 +5987,6 @@
         "indent-string": "^2.1.0",
         "strip-indent": "^1.0.1"
       }
-    },
-    "redux": {
-      "version": "3.7.2",
-      "resolved": "https://registry.npmjs.org/redux/-/redux-3.7.2.tgz",
-      "integrity": "sha512-pNqnf9q1hI5HHZRBkj3bAngGZW/JMCmexDlOxw4XagXY2o1327nHH54LoTjiPJ0gizoqPDRqWyX/00g0hD6w+A==",
-      "dev": true,
-      "requires": {
-        "lodash": "^4.2.1",
-        "lodash-es": "^4.2.1",
-        "loose-envify": "^1.1.0",
-        "symbol-observable": "^1.0.3"
-      }
-    },
-    "redux-form": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/redux-form/-/redux-form-7.2.0.tgz",
-      "integrity": "sha512-qbgeI19drwnm9FeGAotDA1vsZO8q94XF7IxPDuJmSXxDYX2rqzhND6NROahCBJfBK5xM1cchvmgscO2rry1EEw==",
-      "dev": true,
-      "requires": {
-        "deep-equal": "^1.0.1",
-        "es6-error": "^4.0.0",
-        "hoist-non-react-statics": "^2.3.1",
-        "invariant": "^2.2.2",
-        "is-promise": "^2.1.0",
-        "lodash": "^4.17.3",
-        "lodash-es": "^4.17.3",
-        "prop-types": "^15.5.9"
-      }
-    },
-    "redux-form-validators": {
-      "version": "2.7.5",
-      "resolved": "https://registry.npmjs.org/redux-form-validators/-/redux-form-validators-2.7.5.tgz",
-      "integrity": "sha512-WzEfcdIRcOAv+W33nNj1JDAU2UmV3RBR7RzbdqpUzdlOHhp9x+nCGUX+06TLLsWLBAVQma7FRJOFtmoYojTIDA==",
-      "dev": true
-    },
-    "redux-logger": {
-      "version": "2.10.2",
-      "resolved": "https://registry.npmjs.org/redux-logger/-/redux-logger-2.10.2.tgz",
-      "integrity": "sha1-PFpfCm8yV3wd6t9mVfJX+CxsOTc=",
-      "dev": true,
-      "requires": {
-        "deep-diff": "0.3.4"
-      }
-    },
-    "redux-thunk": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-2.3.0.tgz",
-      "integrity": "sha512-km6dclyFnmcvxhAcrQV2AkZmPQjzPDjgVlQtR0EQjxZPyJ0BnMf3in1ryuR8A2qU0HldVRfxYXbFSKlI3N7Slw==",
-      "dev": true
-    },
-    "regenerator-runtime": {
-      "version": "0.10.5",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz",
-      "integrity": "sha1-M2w+/BIgrc7dosn6tntaeVWjNlg=",
-      "dev": true
     },
     "regex-not": {
       "version": "1.0.2",
@@ -7624,16 +6241,6 @@
         }
       }
     },
-    "scheduler": {
-      "version": "0.13.6",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.13.6.tgz",
-      "integrity": "sha512-IWnObHt413ucAYKsD9J1QShUKkbKLQQHdxRyw73sw4FN26iWr3DY/H34xGPe4nmL1DwXyWmSWmMrA9TfQbE/XQ==",
-      "dev": true,
-      "requires": {
-        "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1"
-      }
-    },
     "schema-utils": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-1.0.0.tgz",
@@ -7665,18 +6272,6 @@
           }
         }
       }
-    },
-    "seamless-immutable": {
-      "version": "7.1.4",
-      "resolved": "https://registry.npmjs.org/seamless-immutable/-/seamless-immutable-7.1.4.tgz",
-      "integrity": "sha512-XiUO1QP4ki4E2PHegiGAlu6r82o5A+6tRh7IkGGTVg/h+UoeX4nFBeCGPOhb4CYjvkqsfm/TUtvOMYC1xmV30A==",
-      "dev": true
-    },
-    "select2": {
-      "version": "3.5.2-browserify",
-      "resolved": "https://registry.npmjs.org/select2/-/select2-3.5.2-browserify.tgz",
-      "integrity": "sha1-3E2v2jjWenNOipekbw01Ka4FOR0=",
-      "dev": true
     },
     "semver": {
       "version": "5.6.0",
@@ -7980,13 +6575,6 @@
         }
       }
     },
-    "sortabular": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/sortabular/-/sortabular-1.6.0.tgz",
-      "integrity": "sha512-rKOAXc3Z5JXCeMR1FV6Yuh5HSQUAUyMpEBni5qgO84FBv+C9p4yZ4GnHDhFTyfyMCo7qMS+ZF8ffzXApUOzTBg==",
-      "dev": true,
-      "optional": true
-    },
     "source-list-map": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/source-list-map/-/source-list-map-2.0.1.tgz",
@@ -8245,12 +6833,6 @@
         "has-flag": "^3.0.0"
       }
     },
-    "symbol-observable": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.2.0.tgz",
-      "integrity": "sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ==",
-      "dev": true
-    },
     "table": {
       "version": "5.2.3",
       "resolved": "https://registry.npmjs.org/table/-/table-5.2.3.tgz",
@@ -8290,13 +6872,6 @@
           }
         }
       }
-    },
-    "table-resolver": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/table-resolver/-/table-resolver-3.3.0.tgz",
-      "integrity": "sha512-BkdhtKYhWtXK54GeACs0khqlMvJ53puOw01tzIPsPUr3PP2pFeq9AelPUb7Iy7NeHMyIUI6vEfnngoWgEG+rLQ==",
-      "dev": true,
-      "optional": true
     },
     "tapable": {
       "version": "1.1.1",
@@ -8526,31 +7101,10 @@
         "mime-types": "~2.1.18"
       }
     },
-    "typed-styles": {
-      "version": "0.0.7",
-      "resolved": "https://registry.npmjs.org/typed-styles/-/typed-styles-0.0.7.tgz",
-      "integrity": "sha512-pzP0PWoZUhsECYjABgCGQlRGL1n7tOHsgwYv3oIiEpJwGhFTuty/YNeduxQYzXXa3Ge5BdT6sHYIQYpl4uJ+5Q==",
-      "dev": true
-    },
     "typedarray": {
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
-    },
-    "ua-parser-js": {
-      "version": "0.7.19",
-      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.19.tgz",
-      "integrity": "sha512-T3PVJ6uz8i0HzPxOF9SWzWAlfN/DavlpQqepn22xgve/5QecC+XMCAtmUNnY7C9StehaV6exjUCI801lOI7QlQ==",
-      "dev": true
-    },
-    "uncontrollable": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/uncontrollable/-/uncontrollable-4.1.0.tgz",
-      "integrity": "sha1-4DWCkSUuGGUiLZCTmxny9J+Bwak=",
-      "dev": true,
-      "requires": {
-        "invariant": "^2.1.0"
-      }
     },
     "union-value": {
       "version": "1.0.0",
@@ -8670,12 +7224,6 @@
         "punycode": "^2.1.0"
       }
     },
-    "urijs": {
-      "version": "1.19.1",
-      "resolved": "https://registry.npmjs.org/urijs/-/urijs-1.19.1.tgz",
-      "integrity": "sha512-xVrGVi94ueCJNrBSTjWqjvtgvl3cyOTThp2zaMaFNGp3F542TR6sM3f2o8RqZl+AwteClSVmoCyt0ka4RjQOQg==",
-      "dev": true
-    },
     "urix": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
@@ -8783,21 +7331,6 @@
       "dev": true,
       "requires": {
         "indexof": "0.0.1"
-      }
-    },
-    "w3c-blob": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/w3c-blob/-/w3c-blob-0.0.1.tgz",
-      "integrity": "sha1-sM01KhpQ9RVWNCD/1YYflQ8dhbg=",
-      "dev": true
-    },
-    "warning": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/warning/-/warning-3.0.0.tgz",
-      "integrity": "sha1-MuU3fLVy3kqwR1O9+IIcAe1gW3w=",
-      "dev": true,
-      "requires": {
-        "loose-envify": "^1.0.0"
       }
     },
     "watchpack": {
@@ -8992,12 +7525,6 @@
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/webpack-stats-plugin/-/webpack-stats-plugin-0.2.1.tgz",
       "integrity": "sha512-OYMZLpZrK/qLA79NE4kC4DCt85h/5ipvWJcsefKe9MMw0qU4/ck/IJg+4OmWA+5EfrZZpHXDq92IptfYDWVfkw==",
-      "dev": true
-    },
-    "whatwg-fetch": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.0.0.tgz",
-      "integrity": "sha512-9GSJUgz1D4MfyKU7KRqwOjXCXTqWdFNvEr7eUBYchQiVc744mqK/MzXPNR2WsPkmkOa4ywfg8C2n8h+13Bey1Q==",
       "dev": true
     },
     "which": {
@@ -9290,12 +7817,6 @@
           "dev": true
         }
       }
-    },
-    "zxcvbn": {
-      "version": "4.4.2",
-      "resolved": "https://registry.npmjs.org/zxcvbn/-/zxcvbn-4.4.2.tgz",
-      "integrity": "sha1-KOwXzwl0PtyrBW3dixsGJizHPDA=",
-      "dev": true
     }
   }
 }

--- a/packages/vendor/vendor
+++ b/packages/vendor/vendor
@@ -1,1 +1,0 @@
-../foreman-js/packages/vendor


### PR DESCRIPTION
Stop using `lerna link` as it is not useful.
See #7 about the issue with `lerna link`

## PR Type

<!--- What types of changes does your code introduce? -->

<!-- Put an `x` in all the boxes that apply: -->

* [x] Bugfix
* [ ] Feature
* [ ] Code style update (whitespace, formatting, missing semicolons, etc.)
* [ ] Refactoring (no functional changes, no api changes)
* [ ] Build related changes
* [ ] CI related changes
* [ ] Documentation content changes
* [ ] Other… Please describe:

## Description

Remove the option to use `lerna link` as we should not use it.

## How Has This Been Tested?

Tested locally:

```sh
cd foreman-js
npm install
npm run link
npm run build
# the build should contain 2 versions of react
npm run clean
npm install
npm run build
# the build should be correct
```

To search for react instances in the build result, search inside the `js` file for the term: `@license React`.


## Does this PR introduce a breaking change?

* [ ] Yes
* [x] No

## Checklist:

* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [x] I have read the [`contributing.md`](https://github.com/theforeman/foreman-js/blob/master/contributing.md).
