### PR TITLE
feature(vendor-lodash): limit lodash when using window._

### DIFF
--- a/packages/vendor-core/lib/customModules/lodash.js
+++ b/packages/vendor-core/lib/customModules/lodash.js
@@ -1,0 +1,28 @@
+/**
+ * All the lodash methods are available by importing lodash
+ *  example: `import { get } from 'lodash';`
+ *
+ * `window._` contains only a lean version of lodash
+ * to encourage developers using lodash from webpack.
+ *
+ * The only available methods in `window._` are:
+ * - get
+ * - escape
+ *
+ * Long term goals:
+ * 1. reduce the usage of lodash from the window object
+ * 2. reduce the usage of lodash
+ * 3. optimize lodash to be leaner
+ *
+ * TODO: Once lodash is not relevant to the asset pipline anymore,
+ *       remove this file
+ */
+
+const lodash = require('lodash');
+
+// share limited methods with the window object
+const { get, escape } = lodash;
+window._ = { get, escape };
+
+// share the full lodash module when importing from webpack
+module.exports = lodash;

--- a/packages/vendor-core/lib/modules.js
+++ b/packages/vendor-core/lib/modules.js
@@ -66,6 +66,10 @@ module.exports = [
     path: '@theforeman/vendor-core/lib/customModules/jquery.js',
   },
   {
+    name: 'lodash',
+    path: '@theforeman/vendor-core/lib/customModules/lodash.js',
+  },
+  {
     name: 'jstz',
     window: 'jstz',
   },
@@ -83,7 +87,6 @@ module.exports = [
    */
   'history',
   'number_helpers',
-  'lodash',
   'axios',
   'file-saver',
   'unidiff',


### PR DESCRIPTION
## PR Type

* [ ] Bugfix
* [x] Feature
* [ ] Code style update (whitespace, formatting, missing semicolons, etc.)
* [ ] Refactoring (no functional changes, no api changes)
* [ ] Build related changes
* [ ] CI related changes
* [ ] Documentation content changes
* [ ] Other… Please describe:

## Description

when using lodash by `window._`, only those methods get exposed:
  - get
  - escape

when using lodash by `import lodash from 'lodash'`, all methods are
available

## How Has This Been Tested?

locally against foreman, in luna env

## Checklist:

* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [x] I have read the [`contributing.md`](https://github.com/theforeman/foreman-js/blob/master/contributing.md).
