### PR TITLE
fix(vendor-dev-babel): stop using NODE_ENV in babel

### DIFF
--- a/packages/vendor-dev/README.md
+++ b/packages/vendor-dev/README.md
@@ -18,8 +18,17 @@ npm install --save-dev @theforeman/vendor-dev
 ```
 {
   "presets": [
-    "@theforeman/vendor-dev/babel.preset.js"
-  ]
+    "env",
+    "react"
+  ],
+  "env": {
+    "test": {
+      "presets": ["@theforeman/vendor-dev/babel.preset.js"]
+    },
+    "storybook": {
+      "presets": ["@theforeman/vendor-dev/babel.preset.js"]
+    }
+  }
 }
 
 ```

--- a/packages/vendor-dev/babel.preset.js
+++ b/packages/vendor-dev/babel.preset.js
@@ -7,19 +7,24 @@
   ```
   {
     "presets": [
-      "@theforeman/vendor-dev/babel.preset.js"
-    ]
+      "env",
+      "react"
+    ],
+    "env": {
+      "test": {
+        "presets": ["@theforeman/vendor-dev/babel.preset.js"]
+      },
+      "storybook": {
+        "presets": ["@theforeman/vendor-dev/babel.preset.js"]
+      }
+    }
   }
   ```
- */
+*/
 const resolveBabelPath = require('./lib/resolveBabelPath');
 
-const { NODE_ENV } = process.env;
-
-const plugins = [];
-
-if (NODE_ENV === 'test' || NODE_ENV === 'storybook') {
-  const testPlugins = [
+module.exports = {
+  plugins: [
     [
       require.resolve('babel-plugin-module-resolver'),
       {
@@ -27,8 +32,5 @@ if (NODE_ENV === 'test' || NODE_ENV === 'storybook') {
         resolvePath: resolveBabelPath,
       },
     ],
-  ];
-  plugins.push(...testPlugins);
-}
-
-module.exports = { plugins };
+  ],
+};


### PR DESCRIPTION
## PR Type

* [x] Bugfix
* [ ] Feature
* [ ] Code style update (whitespace, formatting, missing semicolons, etc.)
* [ ] Refactoring (no functional changes, no api changes)
* [ ] Build related changes
* [ ] CI related changes
* [ ] Documentation content changes
* [ ] Other… Please describe:

## Description

Stop using `NODE_ENV` in babel so the consumer will decide on what env to use `foreman-dev/babel`.

## How Has This Been Tested?

Locally in a luna env.

## Does this PR introduce a breaking change?

<!-- If this PR contains a breaking change, -->

<!-- please also describe the impact and migration path for existing applications -->

* [x] Yes
* [ ] No

## Checklist:

<!--- Put an `x` in all the boxes that apply. -->

<!--- If you‘re unsure about any of these, don‘t hesitate to ask. We‘re here to help! -->

* [x] My change requires a change to the documentation.
* [x] I have updated the documentation accordingly.
* [x] I have read the [`contributing.md`](https://github.com/theforeman/foreman-js/blob/master/contributing.md).
