### PR TITLE
feat(vendor-core): add webcomponents polyfills

### DIFF
--- a/packages/vendor-core/lib/modules.js
+++ b/packages/vendor-core/lib/modules.js
@@ -92,4 +92,6 @@ module.exports = [
   'urijs',
   '@novnc/novnc/core/rfb',
   '@spice-project/spice-html5',
+  '@webcomponents/webcomponentsjs/webcomponents-bundle',
+  '@webcomponents/webcomponentsjs/custom-elements-es5-adapter',
 ].map(module => new VendorModule(module));

--- a/packages/vendor-core/package-lock.json
+++ b/packages/vendor-core/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@theforeman/vendor-core",
-	"version": "1.3.0",
+	"version": "1.3.1",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
@@ -398,6 +398,11 @@
 			"resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.7.tgz",
 			"integrity": "sha512-wE2v81i4C4Ol09RtsWFAqg3BUitWbHSpSlIo+bNdsCJijO9sjme+zm+73ZMCa/qMC8UEERxzGbvmr1cffo2SiQ==",
 			"optional": true
+		},
+		"@webcomponents/webcomponentsjs": {
+			"version": "2.2.10",
+			"resolved": "https://registry.npmjs.org/@webcomponents/webcomponentsjs/-/webcomponentsjs-2.2.10.tgz",
+			"integrity": "sha512-5dzhUhP+h0qMiK0IWb7VNb0OGBoXO3AuI6Qi8t9PoKT50s5L1jv0xnwnLq+cFgPuTB8FLTNP8xIDmyoOsKBy9Q=="
 		},
 		"abbrev": {
 			"version": "1.1.1",

--- a/packages/vendor-core/package.json
+++ b/packages/vendor-core/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@novnc/novnc": "^1.0.0",
     "@spice-project/spice-html5": "^0.2.1",
+    "@webcomponents/webcomponentsjs": "^2.2.10",
     "axios": "^0.19.0",
     "babel-polyfill": "^6.26.0",
     "bootstrap-sass": "^3.3.7",


### PR DESCRIPTION
Add support for webcomponents in foreman.

## PR Type

<!--- What types of changes does your code introduce? -->

<!-- Put an `x` in all the boxes that apply: -->

* [ ] Bugfix
* [x] Feature
* [ ] Code style update (whitespace, formatting, missing semicolons, etc.)
* [ ] Refactoring (no functional changes, no api changes)
* [ ] Build related changes
* [ ] CI related changes
* [ ] Documentation content changes
* [ ] Other… Please describe:

## Description

Adds webcomponents and webcomponents polyfills. As I do not understand webpack, I believe some closer look could be needed. @sharvit? :) 

## How Has This Been Tested?

Locally with theforeman/foreman#6735

## Screenshots (if appropriate):

## Does this PR introduce a breaking change?

<!-- If this PR contains a breaking change, -->

<!-- please also describe the impact and migration path for existing applications -->

* [ ] Yes
* [x] No

## Checklist:

<!--- Put an `x` in all the boxes that apply. -->

<!--- If you‘re unsure about any of these, don‘t hesitate to ask. We‘re here to help! -->

* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [x] I have read the [`contributing.md`](https://github.com/theforeman/foreman-js/blob/master/contributing.md).
