### PR TITLE
fix(vendor-core): pin patternfly-react after react-bootstrap update

### DIFF
--- a/packages/vendor-core/package-lock.json
+++ b/packages/vendor-core/package-lock.json
@@ -1330,16 +1330,16 @@
 			}
 		},
 		"patternfly-react": {
-			"version": "2.38.2",
-			"resolved": "https://registry.npmjs.org/patternfly-react/-/patternfly-react-2.38.2.tgz",
-			"integrity": "sha512-eWwCboRnq6brYvihPurq8/O4JpH1t2ZKlftCfLGtRqCzzrKkht2I1Vthhnrw/s0r1CD+F3zkHzvt2RWlPgzwHQ==",
+			"version": "2.39.5",
+			"resolved": "https://registry.npmjs.org/patternfly-react/-/patternfly-react-2.39.5.tgz",
+			"integrity": "sha512-MNhEpoevwzi50yMf6H8YLGfvrEUPGvTq8IqvDW844pOXZB71bQm9bHSLGRGIBpngL7q7i756Eyhe59x8T5y2Lg==",
 			"requires": {
 				"bootstrap-slider-without-jquery": "^10.0.0",
 				"breakjs": "^1.0.0",
 				"classnames": "^2.2.5",
 				"css-element-queries": "^1.0.1",
-				"lodash": "^4.17.11",
-				"patternfly": "^3.58.0",
+				"lodash": "^4.17.15",
+				"patternfly": "^3.59.4",
 				"react-bootstrap": "^0.32.1",
 				"react-bootstrap-switch": "^15.5.3",
 				"react-bootstrap-typeahead": "^3.4.1",
@@ -1355,6 +1355,55 @@
 				"sortabular": "^1.5.1",
 				"table-resolver": "^3.2.0",
 				"uuid": "^3.3.2"
+			},
+			"dependencies": {
+				"jquery": {
+					"version": "3.4.1",
+					"resolved": "https://registry.npmjs.org/jquery/-/jquery-3.4.1.tgz",
+					"integrity": "sha512-36+AdBzCL+y6qjw5Tx7HgzeGCzC81MDDgaUP8ld2zhx58HdqXGoBd+tHdrBMiyjGQs0Hxs/MLZTu/eHNJJuWPw=="
+				},
+				"patternfly": {
+					"version": "3.59.4",
+					"resolved": "https://registry.npmjs.org/patternfly/-/patternfly-3.59.4.tgz",
+					"integrity": "sha512-xkXTmmQFyscfQ/2Vbh8OUFQPPPCgncKb1FMwNwxUXgCjJRqohmkOAR8enMYGNVbFruzrZKxJVOdHnGduLlETDQ==",
+					"requires": {
+						"@types/c3": "^0.6.0",
+						"bootstrap": "~3.4.1",
+						"bootstrap-datepicker": "^1.7.1",
+						"bootstrap-sass": "^3.4.0",
+						"bootstrap-select": "1.12.2",
+						"bootstrap-slider": "^9.9.0",
+						"bootstrap-switch": "3.3.4",
+						"bootstrap-touchspin": "~3.1.1",
+						"c3": "~0.4.11",
+						"d3": "~3.5.17",
+						"datatables.net": "^1.10.15",
+						"datatables.net-colreorder": "^1.4.1",
+						"datatables.net-colreorder-bs": "~1.3.2",
+						"datatables.net-select": "~1.2.0",
+						"drmonty-datatables-colvis": "~1.1.2",
+						"eonasdan-bootstrap-datetimepicker": "^4.17.47",
+						"font-awesome": "^4.7.0",
+						"font-awesome-sass": "^4.7.0",
+						"google-code-prettify": "~1.0.5",
+						"jquery": "~3.4.1",
+						"jquery-match-height": "^0.7.2",
+						"moment": "^2.19.1",
+						"moment-timezone": "^0.4.1",
+						"patternfly-bootstrap-combobox": "~1.1.7",
+						"patternfly-bootstrap-treeview": "~2.1.10"
+					}
+				},
+				"patternfly-bootstrap-treeview": {
+					"version": "2.1.10",
+					"resolved": "https://registry.npmjs.org/patternfly-bootstrap-treeview/-/patternfly-bootstrap-treeview-2.1.10.tgz",
+					"integrity": "sha512-P9+iFu34CwX+R5Fd7/EWbxTug0q9mDj53PnZIIh5ie54KX2kD0+54lCWtpD9SVylDwDtDv3n3A6gbFVkx7HsuA==",
+					"optional": true,
+					"requires": {
+						"bootstrap": "^3.4.1",
+						"jquery": "^3.4.1"
+					}
+				}
 			}
 		},
 		"patternfly-react-extensions": {
@@ -1381,9 +1430,9 @@
 			"integrity": "sha1-M+8wxcd9TqIcWlOGnZG1bY8lVeU="
 		},
 		"popper.js": {
-			"version": "1.15.0",
-			"resolved": "https://registry.npmjs.org/popper.js/-/popper.js-1.15.0.tgz",
-			"integrity": "sha512-w010cY1oCUmI+9KwwlWki+r5jxKfTFDVoadl7MSrIujHU5MJ5OR6HTDj6Xo8aoR/QsA56x8jKjA59qGH4ELtrA=="
+			"version": "1.16.0",
+			"resolved": "https://registry.npmjs.org/popper.js/-/popper.js-1.16.0.tgz",
+			"integrity": "sha512-+G+EkOPoE5S/zChTpmBSSDYmhXJ5PsW8eMhH8cP/CQHMFPBG/kC9Y5IIw6qNYgdJ+/COf0ddY2li28iHaZRSjw=="
 		},
 		"promise": {
 			"version": "7.3.1",
@@ -1627,9 +1676,9 @@
 			"integrity": "sha512-suNP+J1VU1MWFKcyt7RtjiSWUjvidmQSlqu+eHslq+342xCbGTYmC0mEhPCOHxlW0CywylOC1u2DFAT+bv4dBw=="
 		},
 		"react-fontawesome": {
-			"version": "1.6.1",
-			"resolved": "https://registry.npmjs.org/react-fontawesome/-/react-fontawesome-1.6.1.tgz",
-			"integrity": "sha1-7dzhfn3HMaoJ/UoYZoimF5OhbFw=",
+			"version": "1.7.1",
+			"resolved": "https://registry.npmjs.org/react-fontawesome/-/react-fontawesome-1.7.1.tgz",
+			"integrity": "sha512-kottReWW1I9Uupub6A5YX4VK7qfpFnEjAcm5zB4Aepst7iofONT27GJYdTcRsj7q5uQu9PXBL7GsxAFKANNUVg==",
 			"requires": {
 				"prop-types": "^15.5.6"
 			}
@@ -1695,9 +1744,9 @@
 			}
 		},
 		"react-popper": {
-			"version": "1.3.4",
-			"resolved": "https://registry.npmjs.org/react-popper/-/react-popper-1.3.4.tgz",
-			"integrity": "sha512-9AcQB29V+WrBKk6X7p0eojd1f25/oJajVdMZkywIoAV6Ag7hzE1Mhyeup2Q1QnvFRtGQFQvtqfhlEoDAPfKAVA==",
+			"version": "1.3.6",
+			"resolved": "https://registry.npmjs.org/react-popper/-/react-popper-1.3.6.tgz",
+			"integrity": "sha512-kLTfa9z8n+0jJvRVal9+vIuirg41rObg4Bbrvv/ZfsGPQDN9reyVVSxqnHF1ZNgXgV7x11PeUfd5ItF8DZnqhg==",
 			"requires": {
 				"@babel/runtime": "^7.1.2",
 				"create-react-context": "^0.3.0",

--- a/packages/vendor-core/package.json
+++ b/packages/vendor-core/package.json
@@ -51,7 +51,7 @@
     "multiselect": "~0.9.12",
     "number_helpers": "^0.1.1",
     "patternfly": "^3.58.0",
-    "patternfly-react": "^2.38.2",
+    "patternfly-react": "2.39.5",
     "patternfly-react-extensions": "^2.18.8",
     "prop-types": "^15.6.0",
     "react": "^16.9.0",


### PR DESCRIPTION
react-bootstrap update cause tests to fail, until it will be resolved we should use more stable
version of patternfly-react

<!--- Provide a general summary of your changes in the Title above -->

## Updated Packages

<!---
  What packages does your code change?
  Put an `x` in all the boxes that apply:
-->

* [ ] root
* [ ] @theforeman/builder
* [ ] @theforeman/env
* [ ] @theforeman/vendor
* [ ] @theforeman/vendor-dev
* [x] @theforeman/vendor-core

## PR Type

<!---
  What types of changes does your code introduce?
  Put an `x` in all the boxes that apply:
-->

* [x] Bugfix
* [ ] Feature
* [ ] Code style update (whitespace, formatting, missing semicolons, etc.)
* [ ] Refactoring (no functional changes, no api changes)
* [ ] Build related changes
* [ ] CI related changes
* [ ] Documentation content changes
* [ ] Other… Please describe:

## Description

<!---
  Describe your changes in detail
  Why is this change required? What problem does it solve?
  If it fixes an open issue, please link to the issue here.
-->

## Does this PR introduce a breaking change?

<!--
  If this PR contains a breaking change,
  please also describe the impact and migration path for existing applications
-->

* [x] Yes
* [ ] No

## Does this PR fixes open issues?

<!-- If this PR contain fixes to open issues in github or in foreman please link them here -->

* [ ] Yes
* [x] No

## Do you use this PR in another repository?

<!-- If You have a usage example in another repository commit/pr where you are using this PR please link it here  -->

* [ ] Yes
* [ ] No
