### PR TITLE
fix(env): remove tfm-test from package bin

### DIFF
--- a/packages/env/package.json
+++ b/packages/env/package.json
@@ -19,9 +19,6 @@
   "scripts": {
     "test": "echo \"@theforeman/env does not contain any tests at the moment.\""
   },
-  "bin": {
-    "tfm-test": "./bin/tfm-test.js"
-  },
   "dependencies": {
     "babel-jest": "^24.9.0",
     "babel-plugin-dynamic-import-node": "^2.0.0",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Updated Packages

<!---
  What packages does your code change?
  Put an `x` in all the boxes that apply:
-->

* [ ] root
* [ ] @theforeman/builder
* [x] @theforeman/env
* [ ] @theforeman/eslint-plugin-foreman
* [ ] @theforeman/vendor
* [ ] @theforeman/vendor-dev
* [ ] @theforeman/vendor-core

## PR Type

<!---
  What types of changes does your code introduce?
  Put an `x` in all the boxes that apply:
-->

* [x] Bugfix
* [ ] Feature
* [ ] Code style update (whitespace, formatting, missing semicolons, etc.)
* [ ] Refactoring (no functional changes, no api changes)
* [ ] Build related changes
* [ ] CI related changes
* [ ] Documentation content changes
* [ ] Other… Please describe:

## Description

Remove the `tfm-test` from the package bin since the file `./bin/tfm-test.js` does not exist.

## Does this PR introduce a breaking change?

<!--
  If this PR contains a breaking change,
  please also describe the impact and migration path for existing applications
-->

* [ ] Yes
* [x] No

## Does this PR fixes open issues?

<!-- If this PR contain fixes to open issues in github or in foreman please link them here -->

* [x] Yes - Fixes GH-93
* [ ] No

## Do you use this PR in another repository?

<!-- If You have a usage example in another repository commit/pr where you are using this PR please link it here  -->

* [ ] Yes
* [x] No
