### PR TITLE
feat(vendor-core): bump react-router-bootstrap

### DIFF
--- a/packages/vendor-core/package-lock.json
+++ b/packages/vendor-core/package-lock.json
@@ -1867,9 +1867,9 @@
 			}
 		},
 		"react-router-bootstrap": {
-			"version": "0.24.4",
-			"resolved": "https://registry.npmjs.org/react-router-bootstrap/-/react-router-bootstrap-0.24.4.tgz",
-			"integrity": "sha512-kEwk3ml4wvE3IbJvRVjx0zBBBxW4JLhD0wyy0hBdlWSdfjvgoHVvlxx9gBPxvEs5VwWlbFvNRyUghLZ2AMcmzg==",
+			"version": "0.25.0",
+			"resolved": "https://registry.npmjs.org/react-router-bootstrap/-/react-router-bootstrap-0.25.0.tgz",
+			"integrity": "sha512-/22eqxjn6Zv5fvY2rZHn57SKmjmJfK7xzJ6/G1OgxAjLtKVfWgV5sn41W2yiqzbtV5eE4/i4LeDLBGYTqx7jbA==",
 			"requires": {
 				"prop-types": "^15.5.10"
 			}

--- a/packages/vendor-core/package.json
+++ b/packages/vendor-core/package.json
@@ -68,7 +68,7 @@
     "react-onclickoutside": "^6.6.2",
     "react-password-strength": "^2.4.0",
     "react-redux": "^7.1.0",
-    "react-router-bootstrap": "^0.24.4",
+    "react-router-bootstrap": "^0.25.0",
     "react-router-dom": "^5.1.2",
     "redux": "^4.0.4",
     "redux-form": "8.2.0",


### PR DESCRIPTION
After upgrating react-router-dom v5 it broke react-router-bootstrap

<!--- Provide a general summary of your changes in the Title above -->

## Updated Packages

<!---
  What packages does your code change?
  Put an `x` in all the boxes that apply:
-->

* [ ] root
* [ ] @theforeman/builder
* [ ] @theforeman/env
* [ ] @theforeman/eslint-plugin-foreman
* [ ] @theforeman/vendor
* [ ] @theforeman/vendor-dev
* [x] @theforeman/vendor-core

## PR Type

<!---
  What types of changes does your code introduce?
  Put an `x` in all the boxes that apply:
-->

* [ ] Bugfix
* [x] Feature
* [ ] Code style update (whitespace, formatting, missing semicolons, etc.)
* [ ] Refactoring (no functional changes, no api changes)
* [ ] Build related changes
* [ ] CI related changes
* [ ] Documentation content changes
* [ ] Other… Please describe:

## Description

<!---
  Describe your changes in detail
  Why is this change required? What problem does it solve?
  If it fixes an open issue, please link to the issue here.
-->

## Does this PR introduce a breaking change?

<!--
  If this PR contains a breaking change,
  please also describe the impact and migration path for existing applications
-->

* [ ] Yes
* [x] No

## Does this PR fixes open issues?

<!-- If this PR contain fixes to open issues in github or in foreman please link them here -->

* [ ] Yes
* [x] No

## Do you use this PR in another repository?

<!-- If You have a usage example in another repository commit/pr where you are using this PR please link it here  -->

* [x] Yes
* [ ] No
