### PR TITLE
fix(env): use babel-jest transfom workaround for babel config

### DIFF
--- a/packages/env/test/babel.config.js
+++ b/packages/env/test/babel.config.js
@@ -1,5 +1,3 @@
-const babel = require('@theforeman/builder/babel');
-
 module.exports = {
-  presets: [babel],
+  presets: ['@theforeman/builder/babel'],
 };

--- a/packages/env/test/config.js
+++ b/packages/env/test/config.js
@@ -34,7 +34,10 @@ module.exports = {
   },
   transformIgnorePatterns: ['/node_modules/(?!@theforeman/vendor-core/lib/)'],
   transform: {
-    '^.+\\.js$': '<rootDir>/test/jestPreprocess.js',
+    '^.+\\.js$': [
+      'babel-jest',
+      { cwd: path.resolve(__dirname), filename: 'babel.config.js' },
+    ],
   },
   moduleDirectories: [
     '<rootDir>/node_modules',

--- a/packages/env/test/jestPreprocess.js
+++ b/packages/env/test/jestPreprocess.js
@@ -1,3 +1,0 @@
-const babelOptions = require('./babel.config');
-
-module.exports = require('babel-jest').createTransformer(babelOptions);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Hopefully this workaround (taken from [here](https://github.com/theforeman/foreman/pull/7233/files#diff-14e6781502e896261c0a151f0600e9e0R33)) would work. it works locally :pray: 
## Updated Packages

<!---
  What packages does your code change?
  Put an `x` in all the boxes that apply:
-->

* [ ] root
* [ ] @theforeman/builder
* [x] @theforeman/env
* [ ] @theforeman/eslint-plugin-foreman
* [ ] @theforeman/vendor
* [ ] @theforeman/vendor-dev
* [ ] @theforeman/vendor-core

## PR Type

<!---
  What types of changes does your code introduce?
  Put an `x` in all the boxes that apply:
-->

* [x] Bugfix
* [ ] Feature
* [ ] Code style update (whitespace, formatting, missing semicolons, etc.)
* [ ] Refactoring (no functional changes, no api changes)
* [ ] Build related changes
* [ ] CI related changes
* [ ] Documentation content changes
* [ ] Other… Please describe:

## Description

<!---
  Describe your changes in detail
  Why is this change required? What problem does it solve?
  If it fixes an open issue, please link to the issue here.
-->

## Does this PR introduce a breaking change?

<!--
  If this PR contains a breaking change,
  please also describe the impact and migration path for existing applications
-->

* [ ] Yes
* [x] No

## Does this PR fixes open issues?

<!-- If this PR contain fixes to open issues in github or in foreman please link them here -->

* [ ] Yes
* [x] No

## Do you use this PR in another repository?

<!-- If You have a usage example in another repository commit/pr where you are using this PR please link it here  -->

* [ ] Yes
* [ ] No
