### PR TITLE
fix(stories): use mdx-loader on all mdx files

### DIFF
--- a/packages/stories/src/config/webpack/webpack.config.rules.js
+++ b/packages/stories/src/config/webpack/webpack.config.rules.js
@@ -32,7 +32,8 @@ module.exports = ({ config }) => {
 
   // Stories MDX loader
   config.module.rules.push({
-    test: /\.(stories|story)\.mdx$/,
+    test: /\.mdx$/,
+    exclude: /node_modules/,
     use: [
       {
         loader: require.resolve('babel-loader'),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Updated Packages

<!---
  What packages does your code change?
  Put an `x` in all the boxes that apply:
-->

* [ ] root
* [ ] @theforeman/builder
* [ ] @theforeman/env
* [ ] @theforeman/eslint-plugin-foreman
* [x] @theforeman/stories
* [ ] @theforeman/vendor
* [ ] @theforeman/vendor-dev
* [ ] @theforeman/vendor-core

## PR Type

<!---
  What types of changes does your code introduce?
  Put an `x` in all the boxes that apply:
-->

* [x] Bugfix
* [ ] Feature
* [ ] Code style update (whitespace, formatting, missing semicolons, etc.)
* [ ] Refactoring (no functional changes, no api changes)
* [ ] Build related changes
* [ ] CI related changes
* [ ] Documentation content changes
* [ ] Other… Please describe:

## Description

Apply `MDX` on all `*.mdx` instead of `*.stories.mdx`.
`*.stories.mdx` files will continue to get loaded automatically as stories while `*.mdx` won't.

## Does this PR introduce a breaking change?

<!--
  If this PR contains a breaking change,
  please also describe the impact and migration path for existing applications
-->

* [ ] Yes
* [x] No

## Does this PR fixes open issues?

<!-- If this PR contain fixes to open issues in github or in foreman please link them here -->

* [ ] Yes
* [x] No

## Do you use this PR in another repository?

<!-- If You have a usage example in another repository commit/pr where you are using this PR please link it here  -->

* [ ] Yes
* [x] No
