### PR TITLE
fix(builder): update babel-env to transform modules to commonjs

### DIFF
--- a/packages/builder/babel/presets.js
+++ b/packages/builder/babel/presets.js
@@ -1,5 +1,5 @@
 const presets = [
-  require.resolve('@babel/preset-env'),
+  [require.resolve('@babel/preset-env'), { modules: 'commonjs' }],
   require.resolve('@babel/preset-react'),
 ];
 


### PR DESCRIPTION
In order to prevent webpack to do tree-shaking, set modules to commonjs.

ISSUES: refs #28857

<!--- Provide a general summary of your changes in the Title above -->

## Updated Packages

<!---
  What packages does your code change?
  Put an `x` in all the boxes that apply:
-->

* [ ] root
* [x] @theforeman/builder
* [ ] @theforeman/test
* [ ] @theforeman/eslint-plugin-foreman
* [ ] @theforeman/stories
* [ ] @theforeman/vendor
* [ ] @theforeman/vendor-dev
* [ ] @theforeman/vendor-core

## PR Type

<!---
  What types of changes does your code introduce?
  Put an `x` in all the boxes that apply:
-->

* [x] Bugfix
* [ ] Feature
* [ ] Code style update (whitespace, formatting, missing semicolons, etc.)
* [ ] Refactoring (no functional changes, no api changes)
* [ ] Build related changes
* [ ] CI related changes
* [ ] Documentation content changes
* [ ] Other… Please describe:

## Description

<!---
  Describe your changes in detail
  Why is this change required? What problem does it solve?
  If it fixes an open issue, please link to the issue here.
-->

## Does this PR introduce a breaking change?

<!--
  If this PR contains a breaking change,
  please also describe the impact and migration path for existing applications
-->

* [ ] Yes
* [x] No

## Does this PR fixes open issues?

<!-- If this PR contain fixes to open issues in github or in foreman please link them here -->

* [x] Yes - https://projects.theforeman.org/issues/28857
* [ ] No

## Do you use this PR in another repository?

<!-- If You have a usage example in another repository commit/pr where you are using this PR please link it here  -->

* [ ] Yes
* [x] No
