### PR TITLE
fix(vendor-core): adds react-bootstrap-typeahead

### DIFF
--- a/packages/vendor-core/package.json
+++ b/packages/vendor-core/package.json
@@ -62,6 +62,7 @@
     "prop-types": "^15.6.0",
     "react": "^16.9.0",
     "react-ace": "^6.3.2",
+    "react-bootstrap-typeahead": "^3.4.7",
     "react-debounce-input": "^3.2.0",
     "react-diff-view": "^1.8.1",
     "react-dnd": "^9.3.2",


### PR DESCRIPTION
This library should be exist in pf3
but after the pf4 upgrade it was not available

It should fix the issue in foreman, when testing the AutoComplete component.
Should not affect production.

<!--- Provide a general summary of your changes in the Title above -->

## Updated Packages

<!---
  What packages does your code change?
  Put an `x` in all the boxes that apply:
-->

* [ ] root
* [ ] @theforeman/builder
* [ ] @theforeman/test
* [ ] @theforeman/eslint-plugin-foreman
* [ ] @theforeman/stories
* [ ] @theforeman/vendor
* [ ] @theforeman/vendor-dev
* [x] @theforeman/vendor-core
* [ ] @theforeman/find-foreman

## PR Type

<!---
  What types of changes does your code introduce?
  Put an `x` in all the boxes that apply:
-->

* [x] Bugfix
* [ ] Feature
* [ ] Code style update (whitespace, formatting, missing semicolons, etc.)
* [ ] Refactoring (no functional changes, no api changes)
* [ ] Build related changes
* [ ] CI related changes
* [ ] Documentation content changes
* [ ] Other… Please describe:

## Description

<!---
  Describe your changes in detail
  Why is this change required? What problem does it solve?
  If it fixes an open issue, please link to the issue here.
-->

## Does this PR introduce a breaking change?

<!--
  If this PR contains a breaking change,
  please also describe the impact and migration path for existing applications
-->

* [ ] Yes
* [x] No

## Does this PR fixes open issues?

<!-- If this PR contain fixes to open issues in github or in foreman please link them here -->

* [ ] Yes
* [x] No

## Do you use this PR in another repository?

<!-- If You have a usage example in another repository commit/pr where you are using this PR please link it here  -->

* [ ] Yes
* [x] No
