### PR TITLE
feat(vendor-core): upgrade pf3-extensions v3.0.12

### DIFF
--- a/packages/vendor-core/package-lock.json
+++ b/packages/vendor-core/package-lock.json
@@ -755,9 +755,9 @@
 			"integrity": "sha512-JR/iSQOSt+LQIWwrwEzJ9uk0xfN3mTVYMwt1Ir5mUcSN6pU+V4zQFFaJsclJbPuAUQH+yfWef6tm7l1quW3C8Q=="
 		},
 		"clsx": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/clsx/-/clsx-1.0.4.tgz",
-			"integrity": "sha512-1mQ557MIZTrL/140j+JVdRM6e31/OA4vTYxXgqIIZlndyfjHpyawKZia1Im05Vp9BWmImkcNrNtFYQMyFcgJDg=="
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/clsx/-/clsx-1.1.1.tgz",
+			"integrity": "sha512-6/bPho624p3S2pMyvP5kKBPXnI3ufHLObBFCfgx+LkeR5lg2XYy2hqZqUf45ypD8COn2bhgGJSUE+l5dhNBieA=="
 		},
 		"collapse-white-space": {
 			"version": "1.0.6",
@@ -1479,11 +1479,6 @@
 			"resolved": "https://registry.npmjs.org/leven/-/leven-2.1.0.tgz",
 			"integrity": "sha1-wuep93IJTe6dNCAq6KzORoeHVYA="
 		},
-		"linear-layout-vector": {
-			"version": "0.0.1",
-			"resolved": "https://registry.npmjs.org/linear-layout-vector/-/linear-layout-vector-0.0.1.tgz",
-			"integrity": "sha1-OYEU1zA7bsx/1rJzr3uEAdi6nHA="
-		},
 		"lodash": {
 			"version": "4.17.15",
 			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
@@ -1882,21 +1877,98 @@
 			}
 		},
 		"patternfly-react-extensions": {
-			"version": "2.19.8",
-			"resolved": "https://registry.npmjs.org/patternfly-react-extensions/-/patternfly-react-extensions-2.19.8.tgz",
-			"integrity": "sha512-cEFnpkPbpnAj/OV+mJ8sNCH+pVlbB3kE5SWqBJYEIH1H0SLoqkl4a6NKOlpflDTlOC7Ypl5fm1Cf8jeb0rtuPg==",
+			"version": "3.0.12",
+			"resolved": "https://registry.npmjs.org/patternfly-react-extensions/-/patternfly-react-extensions-3.0.12.tgz",
+			"integrity": "sha512-TkUWn47c0vyYj72R9kh0l0N5UdW/buzTrlCNDC3sNz9G8I371QKLZR2sJyHtOWsUZthjRwP9QBs4vMOSZeWTFA==",
 			"requires": {
 				"breakjs": "^1.0.0",
 				"classnames": "^2.2.5",
 				"css-element-queries": "^1.0.1",
-				"patternfly": "^3.58.0",
-				"patternfly-react": "^2.36.8",
-				"react-bootstrap": "^0.32.1",
+				"patternfly": "^3.59.4",
+				"patternfly-react": "^2.39.16",
+				"react-bootstrap": "^0.33.0",
 				"react-click-outside": "^3.0.1",
 				"react-diff-view": "^1.8.1",
 				"react-ellipsis-with-tooltip": "^1.0.8",
 				"react-virtualized": "^9.21.1",
 				"unidiff": "^1.0.1"
+			},
+			"dependencies": {
+				"jquery": {
+					"version": "3.4.1",
+					"resolved": "https://registry.npmjs.org/jquery/-/jquery-3.4.1.tgz",
+					"integrity": "sha512-36+AdBzCL+y6qjw5Tx7HgzeGCzC81MDDgaUP8ld2zhx58HdqXGoBd+tHdrBMiyjGQs0Hxs/MLZTu/eHNJJuWPw=="
+				},
+				"patternfly": {
+					"version": "3.59.5",
+					"resolved": "https://registry.npmjs.org/patternfly/-/patternfly-3.59.5.tgz",
+					"integrity": "sha512-SMQynv9eFrWWG0Ujta5+jPjxHdQB3xkTLiDW5VP8XXc0nGUxXb4EnZh21qiMeGGJYaKpu9CzaPEpCvuBxgYWHQ==",
+					"requires": {
+						"@types/c3": "^0.6.0",
+						"bootstrap": "~3.4.1",
+						"bootstrap-datepicker": "^1.7.1",
+						"bootstrap-sass": "^3.4.0",
+						"bootstrap-select": "1.12.2",
+						"bootstrap-slider": "^9.9.0",
+						"bootstrap-switch": "3.3.4",
+						"bootstrap-touchspin": "~3.1.1",
+						"c3": "~0.4.11",
+						"d3": "~3.5.17",
+						"datatables.net": "^1.10.15",
+						"datatables.net-colreorder": "^1.4.1",
+						"datatables.net-colreorder-bs": "~1.3.2",
+						"datatables.net-select": "~1.2.0",
+						"drmonty-datatables-colvis": "~1.1.2",
+						"eonasdan-bootstrap-datetimepicker": "^4.17.47",
+						"font-awesome": "^4.7.0",
+						"font-awesome-sass": "^4.7.0",
+						"google-code-prettify": "~1.0.5",
+						"jquery": "~3.4.1",
+						"jquery-match-height": "^0.7.2",
+						"moment": "^2.19.1",
+						"moment-timezone": "^0.4.1",
+						"patternfly-bootstrap-combobox": "~1.1.7",
+						"patternfly-bootstrap-treeview": "~2.1.10"
+					}
+				},
+				"patternfly-bootstrap-treeview": {
+					"version": "2.1.10",
+					"resolved": "https://registry.npmjs.org/patternfly-bootstrap-treeview/-/patternfly-bootstrap-treeview-2.1.10.tgz",
+					"integrity": "sha512-P9+iFu34CwX+R5Fd7/EWbxTug0q9mDj53PnZIIh5ie54KX2kD0+54lCWtpD9SVylDwDtDv3n3A6gbFVkx7HsuA==",
+					"optional": true,
+					"requires": {
+						"bootstrap": "^3.4.1",
+						"jquery": "^3.4.1"
+					}
+				},
+				"patternfly-react": {
+					"version": "2.39.16",
+					"resolved": "https://registry.npmjs.org/patternfly-react/-/patternfly-react-2.39.16.tgz",
+					"integrity": "sha512-1Om7jt+1CqWgH4O167OsAfVxts35epKwVfmtnmO0Dff1KiivKscVtnwMePJJvXrEeCIHFwWY2L7i2Avvh/3Xeg==",
+					"requires": {
+						"bootstrap-slider-without-jquery": "^10.0.0",
+						"breakjs": "^1.0.0",
+						"classnames": "^2.2.5",
+						"css-element-queries": "^1.0.1",
+						"lodash": "^4.17.15",
+						"patternfly": "^3.59.4",
+						"react-bootstrap": "^0.33.0",
+						"react-bootstrap-switch": "^15.5.3",
+						"react-bootstrap-typeahead": "^3.4.1",
+						"react-c3js": "^0.1.20",
+						"react-click-outside": "^3.0.1",
+						"react-collapse": "^4.0.3",
+						"react-debounce-input": "^3.2.0",
+						"react-ellipsis-with-tooltip": "^1.0.8",
+						"react-fontawesome": "^1.6.1",
+						"react-motion": "^0.5.2",
+						"reactabular-table": "^8.14.0",
+						"recompose": "^0.26.0",
+						"sortabular": "^1.5.1",
+						"table-resolver": "^3.2.0",
+						"uuid": "^3.3.2"
+					}
+				}
 			}
 		},
 		"performance-now": {
@@ -2026,9 +2098,9 @@
 			}
 		},
 		"react-bootstrap": {
-			"version": "0.32.4",
-			"resolved": "https://registry.npmjs.org/react-bootstrap/-/react-bootstrap-0.32.4.tgz",
-			"integrity": "sha512-xj+JfaPOvnvr3ow0aHC7Y3HaBKZNR1mm361hVxVzVX3fcdJNIrfiodbQ0m9nLBpNxiKG6FTU2lq/SbTDYT2vew==",
+			"version": "0.33.1",
+			"resolved": "https://registry.npmjs.org/react-bootstrap/-/react-bootstrap-0.33.1.tgz",
+			"integrity": "sha512-qWTRravSds87P8WC82tETy2yIso8qDqlIm0czsrduCaYAFtHuyLu0XDbUlfLXeRzqgwm5sRk2wRaTNoiVkk/YQ==",
 			"requires": {
 				"@babel/runtime-corejs2": "^7.0.0",
 				"classnames": "^2.2.5",
@@ -2037,11 +2109,26 @@
 				"keycode": "^2.2.0",
 				"prop-types": "^15.6.1",
 				"prop-types-extra": "^1.0.1",
-				"react-overlays": "^0.8.0",
+				"react-overlays": "^0.9.0",
 				"react-prop-types": "^0.4.0",
 				"react-transition-group": "^2.0.0",
-				"uncontrollable": "^5.0.0",
+				"uncontrollable": "^7.0.2",
 				"warning": "^3.0.0"
+			},
+			"dependencies": {
+				"react-overlays": {
+					"version": "0.9.1",
+					"resolved": "https://registry.npmjs.org/react-overlays/-/react-overlays-0.9.1.tgz",
+					"integrity": "sha512-b0asy/zHtRd0i2+2/uNxe3YVprF3bRT1guyr791DORjCzE/HSBMog+ul83CdtKQ1kZ+pLnxWCu5W3BMysFhHdQ==",
+					"requires": {
+						"classnames": "^2.2.5",
+						"dom-helpers": "^3.2.1",
+						"prop-types": "^15.5.10",
+						"prop-types-extra": "^1.0.1",
+						"react-transition-group": "^2.2.1",
+						"warning": "^3.0.0"
+					}
+				}
 			}
 		},
 		"react-bootstrap-switch": {
@@ -2459,17 +2546,45 @@
 			}
 		},
 		"react-virtualized": {
-			"version": "9.21.1",
-			"resolved": "https://registry.npmjs.org/react-virtualized/-/react-virtualized-9.21.1.tgz",
-			"integrity": "sha512-E53vFjRRMCyUTEKuDLuGH1ld/9TFzjf/fFW816PE4HFXWZorESbSTYtiZz1oAjra0MminaUU1EnvUxoGuEFFPA==",
+			"version": "9.21.2",
+			"resolved": "https://registry.npmjs.org/react-virtualized/-/react-virtualized-9.21.2.tgz",
+			"integrity": "sha512-oX7I7KYiUM7lVXQzmhtF4Xg/4UA5duSA+/ZcAvdWlTLFCoFYq1SbauJT5gZK9cZS/wdYR6TPGpX/dqzvTqQeBA==",
 			"requires": {
 				"babel-runtime": "^6.26.0",
 				"clsx": "^1.0.1",
-				"dom-helpers": "^2.4.0 || ^3.0.0",
-				"linear-layout-vector": "0.0.1",
+				"dom-helpers": "^5.0.0",
 				"loose-envify": "^1.3.0",
 				"prop-types": "^15.6.0",
 				"react-lifecycles-compat": "^3.0.4"
+			},
+			"dependencies": {
+				"@babel/runtime": {
+					"version": "7.10.4",
+					"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.10.4.tgz",
+					"integrity": "sha512-UpTN5yUJr9b4EX2CnGNWIvER7Ab83ibv0pcvvHc4UOdrBI5jb8bj+32cCwPX6xu0mt2daFNjYhoi+X7beH0RSw==",
+					"requires": {
+						"regenerator-runtime": "^0.13.4"
+					}
+				},
+				"csstype": {
+					"version": "2.6.11",
+					"resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.11.tgz",
+					"integrity": "sha512-l8YyEC9NBkSm783PFTvh0FmJy7s5pFKrDp49ZL7zBGX3fWkO+N4EEyan1qqp8cwPLDcD0OSdyY6hAMoxp34JFw=="
+				},
+				"dom-helpers": {
+					"version": "5.1.4",
+					"resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-5.1.4.tgz",
+					"integrity": "sha512-TjMyeVUvNEnOnhzs6uAn9Ya47GmMo3qq7m+Lr/3ON0Rs5kHvb8I+SQYjLUSYn7qhEm0QjW0yrBkvz9yOrwwz1A==",
+					"requires": {
+						"@babel/runtime": "^7.8.7",
+						"csstype": "^2.6.7"
+					}
+				},
+				"regenerator-runtime": {
+					"version": "0.13.5",
+					"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.5.tgz",
+					"integrity": "sha512-ZS5w8CpKFinUzOwW3c83oPeVXoNsrLsaCoLtJvAClH135j/R77RuymhiSErhm2lKcwSCIpmvIWSbDkIfAqKQlA=="
+				}
 			}
 		},
 		"reactabular-table": {
@@ -2765,11 +2880,38 @@
 			"integrity": "sha512-8OaIKfzL5cpx8eCMAhhvTlft8GYF8b2eQr6JkCyVdrgjcytyOmPCXrqXFcUnhonRpLlh5yxEZVohm6mzaowUOw=="
 		},
 		"uncontrollable": {
-			"version": "5.1.0",
-			"resolved": "https://registry.npmjs.org/uncontrollable/-/uncontrollable-5.1.0.tgz",
-			"integrity": "sha512-5FXYaFANKaafg4IVZXUNtGyzsnYEvqlr9wQ3WpZxFpEUxl29A3H6Q4G1Dnnorvq9TGOGATBApWR4YpLAh+F5hw==",
+			"version": "7.1.1",
+			"resolved": "https://registry.npmjs.org/uncontrollable/-/uncontrollable-7.1.1.tgz",
+			"integrity": "sha512-EcPYhot3uWTS3w00R32R2+vS8Vr53tttrvMj/yA1uYRhf8hbTG2GyugGqWDY0qIskxn0uTTojVd6wPYW9ZEf8Q==",
 			"requires": {
-				"invariant": "^2.2.4"
+				"@babel/runtime": "^7.6.3",
+				"@types/react": "^16.9.11",
+				"invariant": "^2.2.4",
+				"react-lifecycles-compat": "^3.0.4"
+			},
+			"dependencies": {
+				"@babel/runtime": {
+					"version": "7.10.4",
+					"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.10.4.tgz",
+					"integrity": "sha512-UpTN5yUJr9b4EX2CnGNWIvER7Ab83ibv0pcvvHc4UOdrBI5jb8bj+32cCwPX6xu0mt2daFNjYhoi+X7beH0RSw==",
+					"requires": {
+						"regenerator-runtime": "^0.13.4"
+					}
+				},
+				"@types/react": {
+					"version": "16.9.41",
+					"resolved": "https://registry.npmjs.org/@types/react/-/react-16.9.41.tgz",
+					"integrity": "sha512-6cFei7F7L4wwuM+IND/Q2cV1koQUvJ8iSV+Gwn0c3kvABZ691g7sp3hfEQHOUBJtccl1gPi+EyNjMIl9nGA0ug==",
+					"requires": {
+						"@types/prop-types": "*",
+						"csstype": "^2.2.0"
+					}
+				},
+				"regenerator-runtime": {
+					"version": "0.13.5",
+					"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.5.tgz",
+					"integrity": "sha512-ZS5w8CpKFinUzOwW3c83oPeVXoNsrLsaCoLtJvAClH135j/R77RuymhiSErhm2lKcwSCIpmvIWSbDkIfAqKQlA=="
+				}
 			}
 		},
 		"unherit": {

--- a/packages/vendor-core/package.json
+++ b/packages/vendor-core/package.json
@@ -59,7 +59,7 @@
     "number_helpers": "^0.1.1",
     "patternfly": "^3.58.0",
     "patternfly-react": "^2.39.10",
-    "patternfly-react-extensions": "^2.18.8",
+    "patternfly-react-extensions": "^3.0.12",
     "prop-types": "^15.6.0",
     "rc-input-number": "^6.0.0",
     "react": "^16.9.0",

--- a/packages/vendor/bundle/webpack.config.js
+++ b/packages/vendor/bundle/webpack.config.js
@@ -9,11 +9,6 @@ const createVendorEntry = require('./createVendorEntry');
 const WebpackExportForemanVendorPlugin = require('./WebpackExportForemanVendorPlugin');
 
 const projectRoot = path.resolve(__dirname, '../');
-const nodeModulesPath = path.resolve(projectRoot, './node_modules/');
-const vendorCoreNodeModulesPath = path.resolve(
-  projectRoot,
-  './node_modules/@theforeman/vendor-core/node_modules/'
-);
 
 const [, webpackMode = 'production'] = process.argv
   .find(arg => arg.startsWith('--mode='))
@@ -43,7 +38,7 @@ const config = {
   },
 
   resolve: {
-    modules: [nodeModulesPath, vendorCoreNodeModulesPath],
+    modules: ['node_modules'],
   },
 
   module: {


### PR DESCRIPTION
upgrade patternfly-react-extensions to v3.0.12 so both
patternfly-react and patternfly-react-extensions
would pull the same react-bootstrap version

<!--- Provide a general summary of your changes in the Title above -->

## Updated Packages

<!---
  What packages does your code change?
  Put an `x` in all the boxes that apply:
-->

* [ ] root
* [ ] @theforeman/builder
* [ ] @theforeman/test
* [ ] @theforeman/eslint-plugin-foreman
* [ ] @theforeman/stories
* [ ] @theforeman/vendor
* [ ] @theforeman/vendor-dev
* [x] @theforeman/vendor-core
* [ ] @theforeman/find-foreman

## PR Type

<!---
  What types of changes does your code introduce?
  Put an `x` in all the boxes that apply:
-->

* [ ] Bugfix
* [x] Feature
* [ ] Code style update (whitespace, formatting, missing semicolons, etc.)
* [ ] Refactoring (no functional changes, no api changes)
* [ ] Build related changes
* [ ] CI related changes
* [ ] Documentation content changes
* [ ] Other… Please describe:

## Does this PR introduce a breaking change?

<!--
  If this PR contains a breaking change,
  please also describe the impact and migration path for existing applications
-->

* [ ] Yes
* [x] No

## Does this PR fixes open issues?

<!-- If this PR contain fixes to open issues in github or in foreman please link them here -->

* [ ] Yes
* [x] No

## Do you use this PR in another repository?

<!-- If You have a usage example in another repository commit/pr where you are using this PR please link it here  -->

* [ ] Yes
* [x] No
