### PR TITLE
chore(root): simplify the pr template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,66 +1,8 @@
-<!--- Provide a general summary of your changes in the Title above -->
-
-## Updated Packages
-
 <!---
-  What packages does your code change?
-  Put an `x` in all the boxes that apply:
--->
+  Please use `npm run commit` and read the contribution guide
+  before opening a pull-request.
 
-* [ ] root
-* [ ] @theforeman/builder
-* [ ] @theforeman/test
-* [ ] @theforeman/eslint-plugin-foreman
-* [ ] @theforeman/stories
-* [ ] @theforeman/vendor
-* [ ] @theforeman/vendor-dev
-* [ ] @theforeman/vendor-core
-* [ ] @theforeman/find-foreman
-
-## PR Type
-
-<!---
-  What types of changes does your code introduce?
-  Put an `x` in all the boxes that apply:
--->
-
-* [ ] Bugfix
-* [ ] Feature
-* [ ] Code style update (whitespace, formatting, missing semicolons, etc.)
-* [ ] Refactoring (no functional changes, no api changes)
-* [ ] Build related changes
-* [ ] CI related changes
-* [ ] Documentation content changes
-* [ ] Other… Please describe:
-
-## Description
-
-<!---
-  Describe your changes in detail
+  Also, please describe your changes in detail.
   Why is this change required? What problem does it solve?
   If it fixes an open issue, please link to the issue here.
 -->
-
-## Does this PR introduce a breaking change?
-
-<!--
-  If this PR contains a breaking change,
-  please also describe the impact and migration path for existing applications
--->
-
-* [ ] Yes
-* [ ] No
-
-## Does this PR fixes open issues?
-
-<!-- If this PR contain fixes to open issues in github or in foreman please link them here -->
-
-* [ ] Yes
-* [ ] No
-
-## Do you use this PR in another repository?
-
-<!-- If You have a usage example in another repository commit/pr where you are using this PR please link it here  -->
-
-* [ ] Yes
-* [ ] No


### PR DESCRIPTION
use a simpler pull-request template as most of the information exists
in the commit-message, if used properly with `npm run commit`.
