### PR TITLE
fix(eslint-plugin-foreman): allow linting plugins without foreman

### DIFF
--- a/.github/workflows/test-with-plugins.yml
+++ b/.github/workflows/test-with-plugins.yml
@@ -15,10 +15,10 @@ jobs:
             use-foreman: true
           - repo: foreman-tasks
             org: theforeman
-            use-foreman: true
+            use-foreman: false
           - repo: foreman_rh_cloud
             org: theforeman
-            use-foreman: true
+            use-foreman: false
     steps:
       - name: Use Node.js
         uses: actions/setup-node@v1

--- a/packages/find-foreman/README.md
+++ b/packages/find-foreman/README.md
@@ -7,9 +7,22 @@ To be used to find Foreman relative to a plugin and return a full path. This is 
 ## Usage
 
 ```javascript
-const { foremanLocation, foremanRelativePath } = require('@theforeman/find-foreman');
+const {
+  foremanLocation,
+  foremanRelativePath,
+  isForemanLocation
+} = require('@theforeman/find-foreman');
 
 const foremanReactRelative = 'webpack/assets/javascripts/react_app';
 const foremanFull = foremanLocation();
 const foremanReactFull = foremanRelativePath(foremanReactRelative);
+
+isForemanLocation('/home/vagrant/foreman');
+// true
+isForemanLocation('/home/vagrant/katello');
+// false
+
+// When not passing arguments, isForemanLocation would use the process.cwd() to determinate if is foreman location.
+isForemanLocation();
+// true / false based on current location
 ```

--- a/packages/find-foreman/index.js
+++ b/packages/find-foreman/index.js
@@ -1,6 +1,14 @@
 const path = require('path');
 const fs = require('fs');
 
+/**
+ * Check if a location is foreman location
+ * @param  {String}  [currentDir=process.cwd()] Location to check
+ * @return {Boolean}                            Is foreman location
+ */
+const isForemanLocation = (currentDir = process.cwd()) =>
+  currentDir.endsWith('/foreman');
+
 // Get full path of Foreman from plugin
 const foremanLocation = () => {
   const relativePaths = ['./foreman', '../foreman', '../../foreman'];
@@ -28,4 +36,4 @@ const foremanRelativePath = innerPath => {
   return result;
 };
 
-module.exports = { foremanLocation, foremanRelativePath };
+module.exports = { isForemanLocation, foremanLocation, foremanRelativePath };

--- a/packages/find-foreman/index.js
+++ b/packages/find-foreman/index.js
@@ -10,7 +10,7 @@ const isForemanLocation = (currentDir = process.cwd()) =>
   currentDir.endsWith('/foreman');
 
 // Get full path of Foreman from plugin
-const foremanLocation = () => {
+const foremanLocation = (throwError = true) => {
   const relativePaths = ['./foreman', '../foreman', '../../foreman'];
   const notFound =
     'Foreman directory cannot be found! This action requires Foreman to be present ' +
@@ -23,7 +23,10 @@ const foremanLocation = () => {
     if (fs.existsSync(result)) fullPath = result;
   });
 
-  if (!fullPath) throw new Error(notFound);
+  if (!fullPath && throwError) {
+    throw new Error(notFound);
+  }
+
   return fullPath;
 };
 

--- a/packages/vendor-dev/eslint.extends.js
+++ b/packages/vendor-dev/eslint.extends.js
@@ -13,23 +13,32 @@
   ```
  */
 const {
+  isForemanLocation,
   foremanLocation,
-  foremanRelativePath,
 } = require('@theforeman/find-foreman');
 const createVendorModulesAliases = require('./lib/createVendorModulesAliases');
 
-const foremanFull = foremanLocation();
+const isPlugin = !isForemanLocation();
+const foreman = foremanLocation(false);
 const foremanVendorRelative = './node_modules/@theforeman/vendor-core/';
-const foremanVendorDir = foremanRelativePath(foremanVendorRelative);
 const foremanTestRelative = './node_modules/@theforeman/test/';
-const foremanTestDir = foremanRelativePath(foremanTestRelative);
+
+const packageJsonDirectories = [
+  './',
+  foremanVendorRelative,
+  foremanTestRelative,
+];
+
+if (isPlugin && foreman) {
+  packageJsonDirectories.push(foremanLocation());
+}
 
 module.exports = {
   rules: {
     'import/no-extraneous-dependencies': [
       'error',
       {
-        packageDir: ['./', foremanFull, foremanVendorDir, foremanTestDir],
+        packageDir: packageJsonDirectories,
       },
     ],
   },


### PR DESCRIPTION
fix an issue when ../foreman/package.json must be presented to be able to run lint

## Updated Packages

<!---
  What packages does your code change?
  Put an `x` in all the boxes that apply:
-->

* [ ] root
* [ ] @theforeman/builder
* [ ] @theforeman/test
* [x] @theforeman/eslint-plugin-foreman
* [ ] @theforeman/stories
* [ ] @theforeman/vendor
* [ ] @theforeman/vendor-dev
* [ ] @theforeman/vendor-core
* [x] @theforeman/find-foreman

## PR Type

<!---
  What types of changes does your code introduce?
  Put an `x` in all the boxes that apply:
-->

* [x] Bugfix
* [x] Feature
* [ ] Code style update (whitespace, formatting, missing semicolons, etc.)
* [ ] Refactoring (no functional changes, no api changes)
* [ ] Build related changes
* [ ] CI related changes
* [ ] Documentation content changes
* [ ] Other… Please describe:

## Does this PR introduce a breaking change?

<!--
  If this PR contains a breaking change,
  please also describe the impact and migration path for existing applications
-->

* [ ] Yes
* [x] No

## Does this PR fixes open issues?

<!-- If this PR contain fixes to open issues in github or in foreman please link them here -->

* [ ] Yes
* [x] No

## Do you use this PR in another repository?

<!-- If You have a usage example in another repository commit/pr where you are using this PR please link it here  -->

* [ ] Yes
* [x] No
