### PR TITLE
refactor(root): refactor gh-actions to multiple files

### DIFF
--- a/.github/workflows/test-foreman-js.yml
+++ b/.github/workflows/test-foreman-js.yml
@@ -1,0 +1,35 @@
+name: foreman-js ci
+on:
+  pull_request:
+    branches: [master]
+
+jobs:
+  test-foreman-js:
+    runs-on: ubuntu-latest
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    continue-on-error: true
+    steps:
+      - name: Use Node.js
+        uses: actions/setup-node@v1
+        with:
+          node-version: 12.x
+      - name: Checkout foreman-js
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Install foreman-js npm dependencies
+        run: npm install
+      - name: Build foreman-js
+        run: npm run build
+      - name: Run foreman-js commit linter
+        if: ${{ always() }}
+        uses: wagoid/commitlint-github-action@v1
+        with:
+          configFile: .commitlintrc.json
+      - name: Run foreman-js lint
+        if: ${{ always() }}
+        run: npm run lint
+      - name: Run foreman-js test
+        if: ${{ always() }}
+        run: npm run test

--- a/.github/workflows/test-with-foreman.yml
+++ b/.github/workflows/test-with-foreman.yml
@@ -1,0 +1,40 @@
+name: foreman-js ci
+on:
+  pull_request:
+    branches: [master]
+
+jobs:
+
+  test-with-foreman:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+    steps:
+      - name: Use Node.js
+        uses: actions/setup-node@v1
+        with:
+          node-version: 12.x
+      - name: Checkout foreman-js
+        uses: actions/checkout@v2
+        with:
+          path: ./projects/foreman-js
+      - name: Checkout foreman
+        uses: actions/checkout@v2
+        with:
+          repository: theforeman/foreman
+          path: ./projects/foreman
+      - name: Install foreman-js npm dependencies
+        run: npm install
+        working-directory: ${{ github.workspace }}/projects/foreman-js
+      - name: Install foreman npm dependencies
+        run: npm install
+        working-directory: ${{ github.workspace }}/projects/foreman
+      - name: Link foreman-js to foreman
+        run: npm run link -- --location '${{ github.workspace }}/projects/foreman'
+        working-directory: ${{ github.workspace }}/projects/foreman-js
+      - name: Run ${{ matrix.repo }} tests
+        run: npm test
+        working-directory: ${{ github.workspace }}/projects/foreman
+      - name: Run ${{ matrix.repo }} lint
+        run: npm run lint
+        working-directory: ${{ github.workspace }}/projects/foreman

--- a/.github/workflows/test-with-plugins.yml
+++ b/.github/workflows/test-with-plugins.yml
@@ -4,48 +4,21 @@ on:
     branches: [master]
 
 jobs:
-  build:
-    runs-on: ubuntu-latest
-    env:
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-    continue-on-error: true
-    steps:
-      - name: Use Node.js
-        uses: actions/setup-node@v1
-        with:
-          node-version: 12.x
-      - name: Checkout foreman-js
-        uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
-      - name: Install foreman-js npm dependencies
-        run: npm install
-      - name: Build foreman-js
-        run: npm run build
-      - name: Run foreman-js commit linter
-        if: ${{ always() }}
-        uses: wagoid/commitlint-github-action@v1
-        with:
-          configFile: .commitlintrc.json
-      - name: Run foreman-js lint
-        if: ${{ always() }}
-        run: npm run lint
-      - name: Run foreman-js test
-        if: ${{ always() }}
-        run: npm run test
-
-  test:
+  test-with-plugins:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
         include:
-          - repo: foreman
-            org: theforeman
           - repo: katello
             org: Katello
+            use-foreman: true
           - repo: foreman-tasks
             org: theforeman
+            use-foreman: true
+          - repo: foreman_rh_cloud
+            org: theforeman
+            use-foreman: true
     steps:
       - name: Use Node.js
         uses: actions/setup-node@v1
@@ -55,20 +28,12 @@ jobs:
         uses: actions/checkout@v2
         with:
           path: ./projects/foreman-js
-      - name: Install foreman-js npm dependencies
-        run: npm install
-        working-directory: ${{ github.workspace }}/projects/foreman-js
       - name: Checkout foreman
+        if: ${{ matrix.use-foreman }}
         uses: actions/checkout@v2
         with:
           repository: theforeman/foreman
           path: ./projects/foreman
-      - name: Install foreman npm dependencies
-        run: npm install
-        working-directory: ${{ github.workspace }}/projects/foreman
-      - name: Link foreman to foreman-js
-        run: npm run link -- --location '${{ github.workspace }}/projects/foreman'
-        working-directory: ${{ github.workspace }}/projects/foreman-js
       - name: Checkout ${{ matrix.repo }}
         if: ${{ matrix.repo != 'foreman' }}
         uses: actions/checkout@v2
@@ -76,12 +41,22 @@ jobs:
           repository: ${{ matrix.org }}/${{ matrix.repo }}
           ref: ${{ matrix.ref }}
           path: ./projects/${{ matrix.repo }}
+      - name: Install foreman-js npm dependencies
+        run: npm install
+        working-directory: ${{ github.workspace }}/projects/foreman-js
+      - name: Install foreman npm dependencies
+        if: ${{ matrix.use-foreman }}
+        run: npm install
+        working-directory: ${{ github.workspace }}/projects/foreman
       - name: Install ${{ matrix.repo }} npm dependencies
         if: ${{ matrix.repo != 'foreman' }}
         run: npm install
         working-directory: ${{ github.workspace }}/projects/${{ matrix.repo }}
-      - name: Link ${{ matrix.repo }} to foreman-js
-        if: ${{ matrix.repo == 'foreman-tasks' }}
+      - name: Link foreman-js to foreman
+        if: ${{ matrix.use-foreman }}
+        run: npm run link -- --location '${{ github.workspace }}/projects/foreman'
+        working-directory: ${{ github.workspace }}/projects/foreman-js
+      - name: Link foreman-js to ${{ matrix.repo }}
         run: npm run link -- --location '${{ github.workspace }}/projects/${{ matrix.repo }}'
         working-directory: ${{ github.workspace }}/projects/foreman-js
       - name: Run ${{ matrix.repo }} tests


### PR DESCRIPTION
Refactor the `ci.yml` and split to multiple files.

Also, adds an option to the plugin tests matrix to test with or without foreman.

Many parts of the code are copied between yml files which is not a good practice but the best gh-actions can give us for now.
We might be able to share workflows only if we will implement them in javascript (that's what I understand from the gh-actions docs).

## Updated Packages

<!---
  What packages does your code change?
  Put an `x` in all the boxes that apply:
-->

* [x] root
* [ ] @theforeman/builder
* [ ] @theforeman/test
* [ ] @theforeman/eslint-plugin-foreman
* [ ] @theforeman/stories
* [ ] @theforeman/vendor
* [ ] @theforeman/vendor-dev
* [ ] @theforeman/vendor-core
* [ ] @theforeman/find-foreman

## PR Type

<!---
  What types of changes does your code introduce?
  Put an `x` in all the boxes that apply:
-->

* [ ] Bugfix
* [ ] Feature
* [ ] Code style update (whitespace, formatting, missing semicolons, etc.)
* [ ] Refactoring (no functional changes, no api changes)
* [ ] Build related changes
* [x] CI related changes
* [ ] Documentation content changes
* [ ] Other… Please describe:

## Does this PR introduce a breaking change?

<!--
  If this PR contains a breaking change,
  please also describe the impact and migration path for existing applications
-->

* [ ] Yes
* [x] No

## Does this PR fixes open issues?

<!-- If this PR contain fixes to open issues in github or in foreman please link them here -->

* [ ] Yes
* [x] No

## Do you use this PR in another repository?

<!-- If You have a usage example in another repository commit/pr where you are using this PR please link it here  -->

* [ ] Yes
* [x] No
