### PR TITLE
Update jest config to use find-foreman

### DIFF
--- a/packages/test/bin/tfm-test.js
+++ b/packages/test/bin/tfm-test.js
@@ -13,19 +13,31 @@ program.version(version);
 program
   .allowUnknownOption()
   .option('-p, --plugin', 'plugin support')
-  .option('-c, --config <type>', 'path to alternative config');
+  .option('-c, --config <type>', 
+          'path to alternative jest config that will be used instead of the standard config')
+  .option('-o --override-config <type>',
+          'path to jest config that will be used in addition to the standard config. This will ' + 
+          'override and add additional settings')
 
 program.parse(process.argv);
 
-const { plugin, config } = program;
+const { plugin, config, overrideConfig } = program;
 
-const overrideConfig = () => {
+const jestConfig = () => {
   if (config) return config;
-  return plugin
+  const standardConfig = plugin
     ? `${testRoot}/src/pluginConfig.js`
     : `${testRoot}/src/config.js`;
+  if (overrideConfig) {
+    const parsedStandard = require(standardConfig);
+    const parsedOverride = require(path.resolve(testRoot, overrideConfig));
+    // Jest accepts file names or JSON objects
+    const combinedConfig = JSON.stringify({ ...parsedStandard, ...parsedOverride });
+    return combinedConfig;
+  }
+  return standardConfig;
 };
-const configArg = ['--config', overrideConfig()];
+const configArg = ['--config', jestConfig()];
 const jestArgs = configArg.concat(remainingArgs(program));
 
 const errorHandling = error => {

--- a/packages/test/package.json
+++ b/packages/test/package.json
@@ -27,6 +27,7 @@
     "@testing-library/jest-dom": "^5.3.0",
     "@testing-library/react": "^10.0.2",
     "@theforeman/builder": "^4.13.2",
+    "@theforeman/find-foreman": "^4.13.2",
     "@theforeman/vendor-core": "^4.13.2",
     "axios-mock-adapter": "^1.1.7",
     "babel-jest": "^24.9.0",

--- a/packages/test/src/pluginConfig.js
+++ b/packages/test/src/pluginConfig.js
@@ -1,6 +1,23 @@
+const { foremanLocation, foremanRelativePath } = require('@theforeman/find-foreman')
 const config = require('./config');
+
+const foremanReactRelative = 'webpack/assets/javascripts/react_app';
+const foremanFull = foremanLocation();
+const foremanReactFull = foremanRelativePath(foremanReactRelative);
 
 module.exports = {
   ...config,
+  moduleDirectories: [
+    `${foremanFull}/node_modules`,
+    `${foremanFull}/node_modules/@theforeman/vendor-core/node_modules`,
+    'node_modules',
+  ],
+  modulePathIgnorePatterns: [
+    '<rootDir>/foreman/',
+  ],
+  moduleNameMapper: {
+    ...config.moduleNameMapper,
+    '^foremanReact(.*)$': `${foremanReactFull}/$1`,
+  },
   automock: false,
 };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Updated Packages

<!---
  What packages does your code change?
  Put an `x` in all the boxes that apply:
-->

* [ ] root
* [ ] @theforeman/builder
* [x] @theforeman/test
* [ ] @theforeman/eslint-plugin-foreman
* [ ] @theforeman/stories
* [ ] @theforeman/vendor
* [ ] @theforeman/vendor-dev
* [ ] @theforeman/vendor-core
* [ ] @theforeman/find-foreman

## PR Type

<!---
  What types of changes does your code introduce?
  Put an `x` in all the boxes that apply:
-->

* [ ] Bugfix
* [x] Feature
* [ ] Code style update (whitespace, formatting, missing semicolons, etc.)
* [ ] Refactoring (no functional changes, no api changes)
* [ ] Build related changes
* [ ] CI related changes
* [ ] Documentation content changes
* [ ] Other… Please describe:

## Description

<!---
  Describe your changes in detail
  Why is this change required? What problem does it solve?
  If it fixes an open issue, please link to the issue here.
-->

This will allow plugins to use foreman's node modules during jest tests. Also an option was added to override the standard configuration. This is useful when a plugin doesn't want to completely replace the config, rather override or add to the standard options.

## Does this PR introduce a breaking change?

<!--
  If this PR contains a breaking change,
  please also describe the impact and migration path for existing applications
-->

* [ ] Yes
* [x] No

## Does this PR fixes open issues?

<!-- If this PR contain fixes to open issues in github or in foreman please link them here -->

* [ ] Yes
* [x] No

## Do you use this PR in another repository?

<!-- If You have a usage example in another repository commit/pr where you are using this PR please link it here  -->

* [ ] Yes
* [x] No (not yet)
