### PR TITLE
feat(test): adds MutationObserver shim needed for react-testing-lib

### DIFF
--- a/packages/test/package-lock.json
+++ b/packages/test/package-lock.json
@@ -788,6 +788,11 @@
 				}
 			}
 		},
+		"@sheerun/mutationobserver-shim": {
+			"version": "0.3.3",
+			"resolved": "https://registry.npmjs.org/@sheerun/mutationobserver-shim/-/mutationobserver-shim-0.3.3.tgz",
+			"integrity": "sha512-DetpxZw1fzPD5xUBrIAoplLChO2VB8DlL5Gg+I1IR9b2wPqYIca2WSUxL5g1vLeR4MsQq1NeWriXAVffV+U1Fw=="
+		},
 		"@testing-library/dom": {
 			"version": "7.2.0",
 			"resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-7.2.0.tgz",

--- a/packages/test/package.json
+++ b/packages/test/package.json
@@ -24,6 +24,7 @@
     "tfm-publish-coverage": "./bin/tfm-publish-coverage.js"
   },
   "dependencies": {
+    "@sheerun/mutationobserver-shim": "^0.3.3",
     "@testing-library/jest-dom": "^5.3.0",
     "@testing-library/react": "^10.0.2",
     "@theforeman/builder": "^4.14.2",

--- a/packages/test/src/test_setup.js
+++ b/packages/test/src/test_setup.js
@@ -1,5 +1,6 @@
 import 'core-js/shim';
 import 'regenerator-runtime/runtime';
+import MutationObserver from '@sheerun/mutationobserver-shim';
 
 const { configure } = require('enzyme');
 const Adapter = require('enzyme-adapter-react-16');
@@ -15,3 +16,7 @@ console.error = (message, ...args) => {
   const err = message instanceof Error ? message : new Error(message);
   throw err;
 };
+
+// Needed for react-testing-library
+// see https://github.com/testing-library/dom-testing-library/releases/tag/v7.0.0
+window.MutationObserver = MutationObserver;


### PR DESCRIPTION
Adds MutationObserver shim that is need for JSDOM used by jest in certain react-testing-lib tests.
See option 3 here: https://github.com/testing-library/dom-testing-library/releases/tag/v7.0.0

ISSUES: #30426

<!---
  Please use `npm run commit` and read the contribution guide
  before opening a pull-request.

  Also, please describe your changes in detail.
  Why is this change required? What problem does it solve?
  If it fixes an open issue, please link to the issue here.
-->
