### PR TITLE
fix(vendor-core): export select2

### DIFF
--- a/packages/vendor-core/lib/modules.js
+++ b/packages/vendor-core/lib/modules.js
@@ -102,6 +102,7 @@ module.exports = [
   'unidiff',
   'urijs',
   'yup',
+  'select2',
   '@novnc/novnc/core/rfb',
   '@spice-project/spice-html5',
   '@webcomponents/webcomponentsjs/webcomponents-bundle',


### PR DESCRIPTION
Seems like we are using it but it is not exported properly.

It used to work because we don't directly import it in production but we do in test files so it is needed.