### PR TITLE
chore(root): disable max length for commit message body

### DIFF
--- a/.commitlintrc.json
+++ b/.commitlintrc.json
@@ -2,5 +2,8 @@
   "extends": [
     "@commitlint/config-conventional",
     "cz"
-  ]
+  ],
+  "rules": {
+    "body-max-line-length": [0, "always", 100]
+  }
 }


### PR DESCRIPTION
Dependabot will create the commit body automatically and it sometimes is long. I don't see a big
issue disabling this since the commit body wraps most places

<!---
  Please use `npm run commit` and read the contribution guide
  before opening a pull-request.

  Also, please describe your changes in detail.
  Why is this change required? What problem does it solve?
  If it fixes an open issue, please link to the issue here.
-->
