### PR TITLE
fix(vendor-core): export apollo from vendor

### DIFF
--- a/packages/vendor-core/lib/modules.js
+++ b/packages/vendor-core/lib/modules.js
@@ -9,6 +9,7 @@ module.exports = [
   /**
    * React related
    */
+  '@apollo/client',
   'core-js/shim',
   'regenerator-runtime/runtime',
   'formik',


### PR DESCRIPTION
Make sure apollo is exported from vendor.

Currently, linting gives me `import/no-extraneous-dependencies` complaining apollo is not in foreman's deps:

`'@apollo/client' should be listed in the project's dependencies. Run 'npm i -S @apollo/client' to add it`
<!---
  Please use `npm run commit` and read the contribution guide
  before opening a pull-request.

  Also, please describe your changes in detail.
  Why is this change required? What problem does it solve?
  If it fixes an open issue, please link to the issue here.
-->
