### PR TITLE
fix(vendor-core): export apollo/client/link/batch-http from vendor

### DIFF
--- a/packages/vendor-core/lib/modules.js
+++ b/packages/vendor-core/lib/modules.js
@@ -10,6 +10,7 @@ module.exports = [
    * React related
    */
   '@apollo/client',
+  '@apollo/client/link/batch-http',
   'core-js/shim',
   'regenerator-runtime/runtime',
   'formik',


### PR DESCRIPTION
This is needed to fix the current packaging failure from my testing.

```
+ scl enable tfm '
webpack --bail --config config/webpack.config.js
'
ModuleNotFoundError: Module not found: Error: Can't resolve '@apollo/client/link/batch-http' in '/builddir/build/BUILD/foreman-2.5.0-develop/webpack/assets/javascripts/react_app/Root'
    at factoryCallback (/opt/theforeman/tfm/root/usr/lib/node_modules/webpack/lib/Compilation.js:282:40)
    at factory (/opt/theforeman/tfm/root/usr/lib/node_modules/webpack/lib/NormalModuleFactory.js:237:20)
    at resolver (/opt/theforeman/tfm/root/usr/lib/node_modules/webpack/lib/NormalModuleFactory.js:60:20)
    at asyncLib.parallel (/opt/theforeman/tfm/root/usr/lib/node_modules/webpack/lib/NormalModuleFactory.js:127:20)
    at /opt/theforeman/tfm/root/usr/lib/node_modules/webpack/node_modules/async/dist/async.js:3888:9
    at /opt/theforeman/tfm/root/usr/lib/node_modules/webpack/node_modules/async/dist/async.js:473:16
    at iteratorCallback (/opt/theforeman/tfm/root/usr/lib/node_modules/webpack/node_modules/async/dist/async.js:1062:13)
    at /opt/theforeman/tfm/root/usr/lib/node_modules/webpack/node_modules/async/dist/async.js:969:16
    at /opt/theforeman/tfm/root/usr/lib/node_modules/webpack/node_modules/async/dist/async.js:3885:13
    at resolvers.normal.resolve (/opt/theforeman/tfm/root/usr/lib/node_modules/webpack/lib/NormalModuleFactory.js:119:22)
    at onError (/opt/theforeman/tfm/root/usr/lib/node_modules/webpack/node_modules/enhanced-resolve/lib/Resolver.js:65:10)
    at loggingCallbackWrapper (/opt/theforeman/tfm/root/usr/lib/node_modules/webpack/node_modules/enhanced-resolve/lib/createInnerCallback.js:31:19)
    at runAfter (/opt/theforeman/tfm/root/usr/lib/node_modules/webpack/node_modules/enhanced-resolve/lib/Resolver.js:158:4)
    at innerCallback (/opt/theforeman/tfm/root/usr/lib/node_modules/webpack/node_modules/enhanced-resolve/lib/Resolver.js:146:3)
    at loggingCallbackWrapper (/opt/theforeman/tfm/root/usr/lib/node_modules/webpack/node_modules/enhanced-resolve/lib/createInnerCallback.js:31:19)
    at next (/opt/theforeman/tfm/root/usr/lib/node_modules/webpack/node_modules/tapable/lib/Tapable.js:252:11)
    at /opt/theforeman/tfm/root/usr/lib/node_modules/webpack/node_modules/enhanced-resolve/lib/UnsafeCachePlugin.js:40:4
    at loggingCallbackWrapper (/opt/theforeman/tfm/root/usr/lib/node_modules/webpack/node_modules/enhanced-resolve/lib/createInnerCallback.js:31:19)
    at runAfter (/opt/theforeman/tfm/root/usr/lib/node_modules/webpack/node_modules/enhanced-resolve/lib/Resolver.js:158:4)
    at innerCallback (/opt/theforeman/tfm/root/usr/lib/node_modules/webpack/node_modules/enhanced-resolve/lib/Resolver.js:146:3)
    at loggingCallbackWrapper (/opt/theforeman/tfm/root/usr/lib/node_modules/webpack/node_modules/enhanced-resolve/lib/createInnerCallback.js:31:19)
    at next (/opt/theforeman/tfm/root/usr/lib/node_modules/webpack/node_modules/tapable/lib/Tapable.js:252:11)
    at innerCallback (/opt/theforeman/tfm/root/usr/lib/node_modules/webpack/node_modules/enhanced-resolve/lib/Resolver.js:144:11)
    at loggingCallbackWrapper (/opt/theforeman/tfm/root/usr/lib/node_modules/webpack/node_modules/enhanced-resolve/lib/createInnerCallback.js:31:19)
    at next (/opt/theforeman/tfm/root/usr/lib/node_modules/webpack/node_modules/tapable/lib/Tapable.js:249:35)
    at resolver.doResolve.createInnerCallback (/opt/theforeman/tfm/root/usr/lib/node_modules/webpack/node_modules/enhanced-resolve/lib/DescriptionFilePlugin.js:44:6)
    at loggingCallbackWrapper (/opt/theforeman/tfm/root/usr/lib/node_modules/webpack/node_modules/enhanced-resolve/lib/createInnerCallback.js:31:19)
    at afterInnerCallback (/opt/theforeman/tfm/root/usr/lib/node_modules/webpack/node_modules/enhanced-resolve/lib/Resolver.js:166:11)
    at loggingCallbackWrapper (/opt/theforeman/tfm/root/usr/lib/node_modules/webpack/node_modules/enhanced-resolve/lib/createInnerCallback.js:31:19)
    at next (/opt/theforeman/tfm/root/usr/lib/node_modules/webpack/node_modules/tapable/lib/Tapable.js:249:35)
resolve '@apollo/client/link/batch-http' in '/builddir/build/BUILD/foreman-2.5.0-develop/webpack/assets/javascripts/react_app/Root'
```
