### PR TITLE
refactor(deps): drop flot.jquery library

### DIFF
--- a/packages/vendor-core/lib/customModules/jquery.js
+++ b/packages/vendor-core/lib/customModules/jquery.js
@@ -8,12 +8,6 @@ module.exports = jquery;
 
 require('jquery.cookie');
 require('jquery-ujs');
-require('jquery-flot/excanvas');
-require('jquery-flot');
-require('jquery-flot/jquery.flot.pie');
-require('jquery-flot/jquery.flot.selection');
-require('jquery-flot/jquery.flot.stack');
-require('jquery-flot/jquery.flot.time');
 require('multiselect');
 require('select2');
 require('datatables.net-bs');

--- a/packages/vendor-core/package-lock.json
+++ b/packages/vendor-core/package-lock.json
@@ -3963,11 +3963,6 @@
 			"resolved": "https://registry.npmjs.org/jquery/-/jquery-2.2.4.tgz",
 			"integrity": "sha1-LInWiJterFIqfuoywUUhVZxsvwI="
 		},
-		"jquery-flot": {
-			"version": "0.8.3",
-			"resolved": "https://registry.npmjs.org/jquery-flot/-/jquery-flot-0.8.3.tgz",
-			"integrity": "sha1-onOs9D8TGQ9ueHAYae4kv+8Swio="
-		},
 		"jquery-match-height": {
 			"version": "0.7.2",
 			"resolved": "https://registry.npmjs.org/jquery-match-height/-/jquery-match-height-0.7.2.tgz",

--- a/packages/vendor-core/package.json
+++ b/packages/vendor-core/package.json
@@ -53,7 +53,6 @@
     "ipaddr.js": "~1.2.0",
     "isomorphic-fetch": "^2.2.1",
     "jquery": "~2.2.4",
-    "jquery-flot": "~0.8.3",
     "jquery-ujs": "~1.2.0",
     "jquery.cookie": "~1.4.1",
     "jstz": "~1.0.7",


### PR DESCRIPTION
We don't need flot charts anymore as we use React components only.

BREAKING CHANGE: The flot.jquery has been dropped and can be no longer used.

Core PR to drop the uses: https://github.com/theforeman/foreman/pull/8522