### PR TITLE
feat(vendor-core): add query-string

### DIFF
--- a/packages/vendor-core/lib/modules.js
+++ b/packages/vendor-core/lib/modules.js
@@ -110,6 +110,7 @@ module.exports = [
   'file-saver',
   'unidiff',
   'urijs',
+  'query-string',
   'yup',
   'select2',
   '@novnc/novnc/core/rfb',

--- a/packages/vendor-core/package-lock.json
+++ b/packages/vendor-core/package-lock.json
@@ -2911,6 +2911,11 @@
 				}
 			}
 		},
+		"filter-obj": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/filter-obj/-/filter-obj-1.1.0.tgz",
+			"integrity": "sha1-mzERErxsYSehbgFsbF1/GeCAXFs="
+		},
 		"find-node-modules": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/find-node-modules/-/find-node-modules-2.0.0.tgz",
@@ -8398,6 +8403,17 @@
 			"integrity": "sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc=",
 			"optional": true
 		},
+		"query-string": {
+			"version": "7.0.1",
+			"resolved": "https://registry.npmjs.org/query-string/-/query-string-7.0.1.tgz",
+			"integrity": "sha512-uIw3iRvHnk9to1blJCG3BTc+Ro56CBowJXKmNNAm3RulvPBzWLRqKSiiDk+IplJhsydwtuNMHi8UGQFcCLVfkA==",
+			"requires": {
+				"decode-uri-component": "^0.2.0",
+				"filter-obj": "^1.1.0",
+				"split-on-first": "^1.0.0",
+				"strict-uri-encode": "^2.0.0"
+			}
+		},
 		"quick-lru": {
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-4.0.1.tgz",
@@ -9626,6 +9642,11 @@
 				"through": "2"
 			}
 		},
+		"split-on-first": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/split-on-first/-/split-on-first-1.1.0.tgz",
+			"integrity": "sha512-43ZssAJaMusuKWL8sKUBQXHWOpq8d6CfN/u1p4gUzfJkM05C8rxTmYrkIPTXapZpORA6LkkzcUulJ8FqA7Uudw=="
+		},
 		"split-string": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
@@ -9688,6 +9709,11 @@
 				"duplexer2": "~0.1.0",
 				"readable-stream": "^2.0.2"
 			}
+		},
+		"strict-uri-encode": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-2.0.0.tgz",
+			"integrity": "sha1-ucczDHBChi9rFC3CdLvMWGbONUY="
 		},
 		"string-width": {
 			"version": "2.1.1",

--- a/packages/vendor-core/package.json
+++ b/packages/vendor-core/package.json
@@ -62,6 +62,7 @@
     "patternfly-react": "^2.39.17",
     "patternfly-react-extensions": "^3.0.12",
     "prop-types": "^15.6.0",
+    "query-string": "^7.0.1",
     "rc-input-number": "^6.0.0",
     "react": "^16.9.0",
     "react-ace": "^6.3.2",


### PR DESCRIPTION
Adds query-string package for easy manipulation with query strings.

Very useful and lightweight package that Katello already uses. Other plugins and core might benefit from this as well.
<!---
  Please use `npm run commit` and read the contribution guide
  before opening a pull-request.

  Also, please describe your changes in detail.
  Why is this change required? What problem does it solve?
  If it fixes an open issue, please link to the issue here.
-->
