### PR TITLE
fix(builder): optional chaining in builder

### DIFF
--- a/packages/builder/babel/plugins.js
+++ b/packages/builder/babel/plugins.js
@@ -1,6 +1,7 @@
 module.exports = [
   require.resolve('@babel/plugin-proposal-class-properties'),
   require.resolve('@babel/plugin-proposal-object-rest-spread'),
+  require.resolve('@babel/plugin-proposal-optional-chaining'),
   require.resolve('@babel/plugin-transform-object-assign'),
   require.resolve('@babel/plugin-syntax-dynamic-import'),
 ];


### PR DESCRIPTION
We are using optional chaining, but we do not include this in babel plugins, so on nodejs 10 this is
failing to build.
