### PR TITLE
fix(builder): syntax optional chaining in builder

### DIFF
--- a/packages/builder/babel/plugins.js
+++ b/packages/builder/babel/plugins.js
@@ -4,4 +4,5 @@ module.exports = [
   require.resolve('@babel/plugin-proposal-optional-chaining'),
   require.resolve('@babel/plugin-transform-object-assign'),
   require.resolve('@babel/plugin-syntax-dynamic-import'),
+  require.resolve('@babel/plugin-syntax-optional-chaining'),
 ];


### PR DESCRIPTION
Explicitly declare the plugin-syntax-optional-chaining babel plugin
as well to ensure it is loaded.

Testing this in a build environment, I was seeing better results. Testing this change locally in our build environment is being difficult. So if this change is OK, it would be helpful to include it, get a new build on NPM and then test RPM builds.
