### PR TITLE
refactor(root): remove rh-cloud plugin test

### DIFF
--- a/.github/workflows/test-with-plugins.yml
+++ b/.github/workflows/test-with-plugins.yml
@@ -14,9 +14,6 @@ jobs:
           - repo: foreman-tasks
             org: theforeman
             use-foreman: false
-          - repo: foreman_rh_cloud
-            org: theforeman
-            use-foreman: false
     steps:
       - uses: ruby/setup-ruby@v1
         with:


### PR DESCRIPTION
The rh-cloud plugin isn't fully tested with foreman's latest branch, removing it now as tests are
failing.

<!---
  Please use `npm run commit` and read the contribution guide
  before opening a pull-request.

  Also, please describe your changes in detail.
  Why is this change required? What problem does it solve?
  If it fixes an open issue, please link to the issue here.
-->
