### PR TITLE
feat(vendor-core): bump react-table version

### DIFF
--- a/packages/vendor-core/package-lock.json
+++ b/packages/vendor-core/package-lock.json
@@ -561,32 +561,46 @@
 			"integrity": "sha512-M19+4Z4nA9HnmYILQ16ACNZ4LnYRBCV0AZNpmLeUZWDy30CQLs0HtmczfV4N5wQV+ocLGK6NugCaWYq7OituuA=="
 		},
 		"@patternfly/react-table": {
-			"version": "4.27.30",
-			"resolved": "https://registry.npmjs.org/@patternfly/react-table/-/react-table-4.27.30.tgz",
-			"integrity": "sha512-eubQ6rusNieiazy4Th6yhWsmfohj1Zy0yFpjCZGvJLRTBBIqEneQLuuzbeIZCEX5SIgAsU8EjdUM377KGwedmg==",
+			"version": "4.29.33",
+			"resolved": "https://registry.npmjs.org/@patternfly/react-table/-/react-table-4.29.33.tgz",
+			"integrity": "sha512-L+4fjZnzjwjqr4WRo/jAagYNoP50aAfl+H4JBq/CVm1taoYQ7336hGTxUIYqh9qadJehUkM3m/foy8NmQondqA==",
 			"requires": {
-				"@patternfly/react-core": "^4.128.7",
-				"@patternfly/react-icons": "^4.10.12",
-				"@patternfly/react-styles": "^4.10.12",
-				"@patternfly/react-tokens": "^4.11.13",
+				"@patternfly/react-core": "^4.144.0",
+				"@patternfly/react-icons": "^4.11.7",
+				"@patternfly/react-styles": "^4.11.7",
+				"@patternfly/react-tokens": "^4.12.8",
 				"lodash": "^4.17.19",
 				"tslib": "1.13.0"
 			},
 			"dependencies": {
+				"@patternfly/react-core": {
+					"version": "4.144.0",
+					"resolved": "https://registry.npmjs.org/@patternfly/react-core/-/react-core-4.144.0.tgz",
+					"integrity": "sha512-D4nQfRi4YrkKlBsTtSnpqfEZZyWamTKZfo5QbtdChbZx9mA6JBKrga3Iup4wJVPBzboZD0LdK/wjgdEJ+886WA==",
+					"requires": {
+						"@patternfly/react-icons": "^4.11.7",
+						"@patternfly/react-styles": "^4.11.7",
+						"@patternfly/react-tokens": "^4.12.8",
+						"focus-trap": "6.2.2",
+						"react-dropzone": "9.0.0",
+						"tippy.js": "5.1.2",
+						"tslib": "1.13.0"
+					}
+				},
 				"@patternfly/react-icons": {
-					"version": "4.10.12",
-					"resolved": "https://registry.npmjs.org/@patternfly/react-icons/-/react-icons-4.10.12.tgz",
-					"integrity": "sha512-DpuORXLon75I8CLR61GchjLUB/uQPxHfTMtmofWMsxanYmBdQvJIP5nDC+dSMmptHF23ea1CDGblj76GksxdqA=="
+					"version": "4.11.7",
+					"resolved": "https://registry.npmjs.org/@patternfly/react-icons/-/react-icons-4.11.7.tgz",
+					"integrity": "sha512-ZogGLvdM4qkIMblKDWYDEvgTzRN4b1OBKCDdz7fCsCykJSxX9Uvf5H6PAmpy+q8btztCmX8JBBuqvJDfR3693g=="
 				},
 				"@patternfly/react-styles": {
-					"version": "4.10.12",
-					"resolved": "https://registry.npmjs.org/@patternfly/react-styles/-/react-styles-4.10.12.tgz",
-					"integrity": "sha512-3ASA8u67SUs7vujU4PMkXlXkeVHz+a9aTvIXWmxpuxZjfZt/Qgrthvr5Cua4R4cymHgrJPFGlSMbZ/WBUsdP2w=="
+					"version": "4.11.7",
+					"resolved": "https://registry.npmjs.org/@patternfly/react-styles/-/react-styles-4.11.7.tgz",
+					"integrity": "sha512-ZKsf7OKKNPc85t70s85HSE+ElFRVIEzgmjpqWrNybfZKmjlCNh8IVYY6jwWYBOutSNfFTN43SvJJqnecIXnzUQ=="
 				},
 				"@patternfly/react-tokens": {
-					"version": "4.11.13",
-					"resolved": "https://registry.npmjs.org/@patternfly/react-tokens/-/react-tokens-4.11.13.tgz",
-					"integrity": "sha512-fyKrQgKOTNEGkulyc+1w4a/xmSX1WkVmWBWjJ4hBkCHiQMG1rDOXxXAe1PQjpfjcfYvmkumPfLnZDZwBbbJAuw=="
+					"version": "4.12.8",
+					"resolved": "https://registry.npmjs.org/@patternfly/react-tokens/-/react-tokens-4.12.8.tgz",
+					"integrity": "sha512-sUrjDmf86rn0hxv9RbgTeWjF5uyqN84r/7B9hWIW8gEIIfSfVCWrKYRgRCnekGQXua7TlYeh4IPTeHpAMDXTbw=="
 				}
 			}
 		},

--- a/packages/vendor-core/package.json
+++ b/packages/vendor-core/package.json
@@ -30,7 +30,7 @@
     "@patternfly/react-core": "~4.128.6",
     "@patternfly/react-icons": "~4.10.11",
     "@patternfly/react-styles": "~4.10.11",
-    "@patternfly/react-table": "~4.27.29",
+    "@patternfly/react-table": "~4.29.4",
     "@patternfly/react-tokens": "~4.11.12",
     "@reduxjs/toolkit": "^1.6.0",
     "@spice-project/spice-html5": "^0.2.1",


### PR DESCRIPTION
Bump react-table version so we can use the draggable icon/button for table rows

<!---
  Please use `npm run commit` and read the contribution guide
  before opening a pull-request.

  Also, please describe your changes in detail.
  Why is this change required? What problem does it solve?
  If it fixes an open issue, please link to the issue here.
-->
