### PR TITLE
feat(eslint-plugin-foreman): allow for-of loops

### DIFF
--- a/packages/eslint-plugin-foreman/lib/src/core.js
+++ b/packages/eslint-plugin-foreman/lib/src/core.js
@@ -16,6 +16,24 @@ module.exports = {
         skipComments: true,
       },
     ],
+    'no-restricted-syntax': [
+      'error',
+      {
+        selector: 'ForInStatement',
+        message:
+          'for..in loops iterate over the entire prototype chain, which is virtually never what you want. Use Object.{keys,values,entries}, and iterate over the resulting array.',
+      },
+      {
+        selector: 'LabeledStatement',
+        message:
+          'Labels are a form of GOTO; using them makes code confusing and hard to maintain and understand.',
+      },
+      {
+        selector: 'WithStatement',
+        message:
+          '`with` is disallowed in strict mode because it makes code impossible to predict and optimize.',
+      },
+    ],
     'promise/prefer-await-to-then': 'error',
     'prettier/prettier': [
       'error',


### PR DESCRIPTION
The Javascript `for...of` loop syntax is better than `Array.prototype.forEach` in many situations.

```js
for (const apple of apples) {
   if (apple.bad) continue;
   polishApple(apple);
 }
```

Unlike `for...in` loops which are old-style Javascript and only work on objects, `for-of` is modern Javascript and works on any iterable, including arrays, objects,  sets, strings, etc.

Github actually has an eslint rule that _prohibits_ `forEach`, and they extensively outline why `for-of` is better in their [eslint-plugin-github documentation](https://github.com/github/eslint-plugin-github/blob/main/docs/rules/array-foreach.md), which I highly recommend reading.

For me this is more about having readable code than performance optimization.

I don't think we need to go as far as requiring it, but I do think we shouldn't disallow `for-of`.  This PR turns off the `no-restricted-syntax` eslint rule that prohibits `for-of` loops.