### PR TITLE
Add styles of @redhat-cloud-services

### DIFF
--- a/packages/vendor-core/scss/vendor-core.scss
+++ b/packages/vendor-core/scss/vendor-core.scss
@@ -10,6 +10,7 @@
 @import '~select2/select2.css';
 @import "~dsmorse-gridster/dist/jquery.gridster";
 @import "~datatables.net-bs/css/dataTables.bootstrap.css";
+@import "~@redhat-cloud-services/frontend-components/index.css";
 
 // patternfly v3
 @import '~patternfly-react/dist/sass/_patternfly-react.scss';


### PR DESCRIPTION
We've been getting the error: `Module build failed: ModuleNotFoundError: Module not found: Error: Can't resolve '@redhat-cloud-services/frontend-components/index.css'`

adding it to our styles `vendor-core.scss` should fix it.
<!---
  Please use `npm run commit` and read the contribution guide
  before opening a pull-request.

  Also, please describe your changes in detail.
  Why is this change required? What problem does it solve?
  If it fixes an open issue, please link to the issue here.
-->
