### PR TITLE
fix(stories): handle templateParameters as a promise

### DIFF
--- a/packages/stories/src/config/webpack/webpack.config.vendor.js
+++ b/packages/stories/src/config/webpack/webpack.config.vendor.js
@@ -19,19 +19,27 @@ module.exports = ({ config, mode }) => {
     assets,
     assetTags,
     options
-  ) => ({
-    compilation,
-    webpackConfig: compilation.options,
-    htmlWebpackPlugin: {
-      tags: assetTags,
-      files: {
-        ...assets,
-        js: [...vendorJsFiles, ...assets.js],
-        css: [...vendorCssFiles, ...assets.css],
-      },
-      options,
-    },
-  });
+  ) =>
+    Promise.resolve().then(() => {
+      try {
+        return {
+          compilation,
+          webpackConfig: compilation.options,
+          htmlWebpackPlugin: {
+            tags: assetTags,
+            files: {
+              ...assets,
+              js: [...vendorJsFiles, ...assets.js],
+              css: [...vendorCssFiles, ...assets.css],
+            },
+            options,
+          },
+        };
+      } catch (e) {
+        compilation.errors.push(new Error(`Template execution failed: ${e}`));
+        return Promise.reject(e);
+      }
+    });
 
   config.plugins.push(new WebpackForemanVendorPlugin({ mode }));
 


### PR DESCRIPTION
got an error when trying to run storybook from Foreman: UnhandledPromiseRejectionWarning: TypeError: Cannot read property 'createSnapshot' of
undefined

ISSUES: fixes #393

<!---
  Please use `npm run commit` and read the contribution guide
  before opening a pull-request.

  Also, please describe your changes in detail.
  Why is this change required? What problem does it solve?
  If it fixes an open issue, please link to the issue here.
-->
