### PR TITLE
fix(test): fix custom jest resolver

### DIFF
--- a/packages/test/src/resolveNodeModule.js
+++ b/packages/test/src/resolveNodeModule.js
@@ -43,11 +43,14 @@ const resolveNodeModule = (sourcePath, currentFile) => {
     currentFileDirectory,
   });
 
-  const results = process.version.startsWith('v10')
-    ? currentFile.defaultResolver(moduleToResolve, currentFile)
-    : require.resolve(moduleToResolve, {
-        paths: [currentFileDirectory],
-      });
+  let results;
+  try {
+    results = require.resolve(moduleToResolve, {
+      paths: [currentFileDirectory],
+    });
+  } catch (error) {
+    results = currentFile.defaultResolver(moduleToResolve, currentFile);
+  }
 
   return rootDir
     ? results.replace(


### PR DESCRIPTION
require.resolve Doesn't know how to handle `import * from '..'` (`'..'` is the issue). The jest defaultResolver does know.
`require.resolve` was added here: https://github.com/theforeman/foreman-js/pull/148