### PR TITLE
fix(test): updates commander from v4 to v7

### DIFF
--- a/packages/test/bin/tfm-test.js
+++ b/packages/test/bin/tfm-test.js
@@ -17,7 +17,7 @@ program
 
 program.parse(process.argv);
 
-const { plugin, config } = program;
+const { plugin, config } = program.opts();
 
 const overrideConfig = () => {
   if (config) return config;

--- a/packages/test/package-lock.json
+++ b/packages/test/package-lock.json
@@ -3372,7 +3372,7 @@
 		"boolbase": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
-			"integrity": "sha1-aN/1++YMUes3cl6p4+0xDcwed24="
+			"integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww=="
 		},
 		"bottleneck": {
 			"version": "2.19.5",
@@ -3759,9 +3759,9 @@
 			}
 		},
 		"commander": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/commander/-/commander-4.0.1.tgz",
-			"integrity": "sha512-IPF4ouhCP+qdlcmCedhxX4xiGBPyigb8v5NeUp+0LyhwLgxMqyp3S0vl7TAPfS/hiP7FC3caI/PB9lTmP8r1NA=="
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
+			"integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw=="
 		},
 		"compare-func": {
 			"version": "1.3.2",

--- a/packages/test/package.json
+++ b/packages/test/package.json
@@ -34,7 +34,7 @@
     "babel-jest": "^26.3.0",
     "babel-plugin-dynamic-import-node": "^2.0.0",
     "cheerio": "1.0.0-rc.10",
-    "commander": "^4.0.1",
+    "commander": "^7.2.0",
     "coveralls": "^3.0.9",
     "enzyme": "^3.11.0",
     "enzyme-adapter-react-16": "^1.15.2",

--- a/packages/test/src/helpers/index.js
+++ b/packages/test/src/helpers/index.js
@@ -13,7 +13,7 @@ module.exports = {
       execArgs.reduce((memo, current) => memo || item.endsWith(current), false);
 
     return (
-      cli.rawArgs
+      cli.args
         // Only retain elements starting from the first --option
         .reduce(
           (acc, item) =>
@@ -22,38 +22,6 @@ module.exports = {
               : acc,
           []
         )
-        // Filter out arguments already parsed by commander.js
-        .filter((rawArg, index, rawArgs) => {
-          // --option=B, --oB
-          const matches =
-            rawArg.match(/^(--.+)=(.+)$/) || rawArg.match(/^(-[^-])(.+)$/);
-          if (matches) {
-            const [, option] = matches;
-            if (cli.optionFor(option)) {
-              return false;
-            }
-            return true;
-          }
-
-          // If the option is consumed by commander.js, then we skip it
-          if (cli.optionFor(rawArg)) {
-            return false;
-          }
-
-          // If it's an argument of an option consumed by commander.js, then we
-          // skip it too
-          const previousRawArg = rawArgs[index - 1];
-          const previousOption = cli.optionFor(previousRawArg);
-          if (previousOption) {
-            // Option consumed by commander.js
-            const previousKey = previousOption.attributeName();
-            if (cli[previousKey] === rawArg) {
-              return false;
-            }
-          }
-
-          return true;
-        })
     );
   },
 


### PR DESCRIPTION
tests use the newest version of the package it can find, and because `webpack-bundle-analyzer` got auto updated, it installs `commander` v7, which doesn't support optionFor.
before: 
running tests with options will fail.
example: `npm test -- webpack/assets/javascripts/react_app/components/Layout/components/ImpersonateIcon/ImpersonateIcon.test.js -u`

```
foreman-js/packages/test/src/helpers/index.js:43
          if (cli.optionFor(rawArg)) {
                  ^

TypeError: cli.optionFor is not a function
    at foreman-js/packages/test/src/helpers/index.js:43:19
    at Array.filter (<anonymous>)
    at remainingArgs (foreman-js/packages/test/src/helpers/index.js:30:10)
    at Object.<anonymous> (foreman-js/packages/test/bin/tfm-test.js:30:35)
```