### PR TITLE
refactor(vendor-core): change @novnc module export

### DIFF
--- a/packages/vendor-core/lib/modules.js
+++ b/packages/vendor-core/lib/modules.js
@@ -114,7 +114,7 @@ module.exports = [
   'urijs',
   'yup',
   'select2',
-  '@novnc/novnc/core/rfb',
+  '@novnc/novnc',
   '@spice-project/spice-html5',
   '@webcomponents/webcomponentsjs/webcomponents-bundle',
   '@webcomponents/webcomponentsjs/custom-elements-es5-adapter',


### PR DESCRIPTION
There's an issue with @novnc internal files that gets loaded too early in Foreman.

<!---
  Please use `npm run commit` and read the contribution guide
  before opening a pull-request.

  Also, please describe your changes in detail.
  Why is this change required? What problem does it solve?
  If it fixes an open issue, please link to the issue here.
-->
