### PR TITLE
fix(vendor-dev): fix lint failures when theforeman/stories is not ins…

### DIFF
--- a/packages/vendor-dev/eslint.extends.js
+++ b/packages/vendor-dev/eslint.extends.js
@@ -17,6 +17,7 @@ const {
   foremanLocation,
 } = require('@theforeman/find-foreman');
 const createVendorModulesAliases = require('./lib/createVendorModulesAliases');
+const fs = require('fs');
 
 const isPlugin = !isForemanLocation();
 const foreman = foremanLocation(false);
@@ -28,8 +29,11 @@ const packageJsonDirectories = [
   './',
   foremanVendorRelative,
   foremanTestRelative,
-  foremanStoriesRelative,
 ];
+
+if (fs.existsSync(foremanStoriesRelative)) {
+  packageJsonDirectories.push(foremanStoriesRelative);
+}
 
 if (isPlugin && foreman) {
   packageJsonDirectories.push(foremanLocation());


### PR DESCRIPTION
When running `tfm-lint`  in foreman, when `@theforeman/stories` is not installed, 
we get `The package.json file could not be found import/no-extraneous-dependencies` in each file.
In this fix we check if foreman/stories is installed, and if it isn't eslint will not look for a package.json in it. 