### PR TITLE
feat(eslint-plugin-rules): checking for ouiaId in pf4 components only

### DIFF
--- a/packages/eslint-plugin-rules/lib/require-ouiaid.js
+++ b/packages/eslint-plugin-rules/lib/require-ouiaid.js
@@ -2,6 +2,7 @@ const getProp = require('jsx-ast-utils/getProp');
 
 module.exports = {
   create(context) {
+    const patternflyImports = new Set();
     const options = context.options.length
       ? context.options
       : [
@@ -44,17 +45,39 @@ module.exports = {
           'Tr',
         ];
 
-    return {
-      JSXElement(node) {
-        if (!options.includes(node.openingElement.name.name)) {
-          return;
-        }
+    function addPatternflyImport(node) {
+      if (
+        node.type === 'ImportDeclaration' &&
+        node.source.value.startsWith('@patternfly/react')
+      ) {
+        node.specifiers.forEach((specifier) => {
+          if (specifier.type === 'ImportSpecifier') {
+            patternflyImports.add(specifier.local.name);
+          }
+        });
+      }
+    }
 
-        const ouiaIdProp = getProp(node.openingElement.attributes, 'ouiaId');
+    function checkPatternflyComponent(node) {
+      if (!options.includes(node.name.name)) {
+        return;
+      }
+      if (
+        node.type === 'JSXOpeningElement' &&
+        patternflyImports.has(node.name.name)
+      ) {
+        const ouiaIdProp = getProp(node.attributes, 'ouiaId');
         if (!ouiaIdProp) {
-          context.report({ node, message: 'ouiaId property is missing' });
+          context.report({
+            node,
+            message: `ouiaId property is missing in PatternFly component '${node.name.name}'`,
+          });
         }
-      },
+      }
+    }
+    return {
+      ImportDeclaration: addPatternflyImport,
+      JSXOpeningElement: checkPatternflyComponent,
     };
   },
 };


### PR DESCRIPTION
This eslint rule failed in foreman core for components with the same name, that were imported from somewhere else, like from `patternfly-react` or just, for example `import Text from '../Text';` .
