### PR TITLE
feat(eslint-plugin-rules): update eslint-plugin-rules for PF5

### DIFF
--- a/packages/eslint-plugin-rules/README.md
+++ b/packages/eslint-plugin-rules/README.md
@@ -26,14 +26,25 @@ If not specified in the eslintrc file, these components will be checked for an `
   "Checkbox",
   "Chip",
   "ChipGroup",
+  "Content",
   "ContextSelector",
   "Dropdown",
   "DropdownItem",
+  "DropdownList",
   "DropdownSeparator",
   "DropdownToggle",
   "DropdownToggleCheckbox",
+  "DualListSelector",
+  "EmptyState",
+  "EmptyStateActions",
+  "EmptyStateBody",
+  "EmptyStateFooter",
+  "EmptyStateHeader",
   "FormSelect",
+  "KebabToggle",
+  "Masthead",
   "Menu",
+  "MenuToggle",
   "Modal",
   "ModalBoxCloseButton",
   "ModalContent",
@@ -41,24 +52,29 @@ If not specified in the eslintrc file, these components will be checked for an `
   "NavExpandable",
   "NavItem",
   "OptionsMenu",
+  "Page",
+  "PageSidebar",
   "Pagination",
   "Radio",
   "RowWrapper",
+  "SearchInput",
   "Select",
   "Switch",
+  "Tab",
   "TabButton",
   "TabContent",
+  "Table",
+  "TableComposable",
   "Tabs",
   "Text",
   "TextInput",
+  "TextInputGroup",
   "Title",
   "Toolbar",
-  "Table",
-  "TableComposable",
   "Tr"
 ```
 
-You can specify what components you want to check against.
+You can specify what components you want to check against. This replaces the default list entirely.
 ```js
 {
   "plugins": ["@theforeman/rules"],
@@ -71,4 +87,18 @@ You can specify what components you want to check against.
   }
 ```
 
-Here is the list of [OUIA-compliant PatternFly 4 components](https://www.patternfly.org/v4/developer-resources/open-ui-automation/).
+You can also extend the default list with additional components without replacing it:
+```js
+{
+  "plugins": ["@theforeman/rules"],
+  "rules": {
+    "@theforeman/rules/require-ouiaid": [
+      "warn",
+      { "additional": ["CustomComponent", "AnotherComponent"] }
+    ]
+  }
+```
+
+Here is the list of OUIA-compliant PatternFly components:
+- [PatternFly 5](https://v5-archive.patternfly.org/developer-resources/open-ui-automation/)
+- [PatternFly 4](https://v4-archive.patternfly.org/v4/developer-resources/open-ui-automation)

--- a/packages/eslint-plugin-rules/lib/require-ouiaid.js
+++ b/packages/eslint-plugin-rules/lib/require-ouiaid.js
@@ -3,48 +3,72 @@ const getProp = require('jsx-ast-utils/getProp');
 module.exports = {
   create(context) {
     const patternflyImports = new Set();
-    const options = context.options.length
-      ? context.options
-      : [
-          'Alert',
-          'Breadcrumb',
-          'Button',
-          'Card',
-          'Checkbox',
-          'Chip',
-          'ChipGroup',
-          'ContextSelector',
-          'Dropdown',
-          'DropdownItem',
-          'DropdownSeparator',
-          'DropdownToggle',
-          'DropdownToggleCheckbox',
-          'FormSelect',
-          'Menu',
-          'Modal',
-          'ModalBoxCloseButton',
-          'ModalContent',
-          'Nav',
-          'NavExpandable',
-          'NavItem',
-          'OptionsMenu',
-          'Pagination',
-          'Radio',
-          'RowWrapper',
-          'Select',
-          'Switch',
-          'TabButton',
-          'TabContent',
-          'Tab',
-          'Tabs',
-          'Text',
-          'TextInput',
-          'Title',
-          'Toolbar',
-          'Table',
-          'TableComposable',
-          'Tr',
-        ];
+    const defaults = [
+      'Alert',
+      'Breadcrumb',
+      'Button',
+      'Card',
+      'Checkbox',
+      'Chip',
+      'ChipGroup',
+      'Content',
+      'ContextSelector',
+      'Dropdown',
+      'DropdownItem',
+      'DropdownList',
+      'DropdownSeparator',
+      'DropdownToggle',
+      'DropdownToggleCheckbox',
+      'DualListSelector',
+      'EmptyState',
+      'EmptyStateActions',
+      'EmptyStateBody',
+      'EmptyStateFooter',
+      'EmptyStateHeader',
+      'FormSelect',
+      'KebabToggle',
+      'Masthead',
+      'Menu',
+      'MenuToggle',
+      'Modal',
+      'ModalBoxCloseButton',
+      'ModalContent',
+      'Nav',
+      'NavExpandable',
+      'NavItem',
+      'OptionsMenu',
+      'Page',
+      'PageSidebar',
+      'Pagination',
+      'Radio',
+      'RowWrapper',
+      'SearchInput',
+      'Select',
+      'Switch',
+      'Tab',
+      'TabButton',
+      'TabContent',
+      'Table',
+      'TableComposable',
+      'Tabs',
+      'Text',
+      'TextInput',
+      'TextInputGroup',
+      'Title',
+      'Toolbar',
+      'Tr',
+    ];
+
+    const { additional } =
+      (context.options.length === 1 && context.options[0]) || {};
+    const { options: contextOptions } = context;
+
+    let options = defaults;
+    if (additional) {
+      options = [...defaults, ...additional];
+    } else if (contextOptions.length) {
+      options = contextOptions;
+    }
 
     function addPatternflyImport(node) {
       if (


### PR DESCRIPTION
Update eslint-plugin-rules for patternfly 5.

**To test**
```
# Copy the updated rule to Foreman's node_modules
cp /home/vagrant/foreman-js/packages/eslint-plugin-rules/lib/require-ouiaid.js \
   /home/vagrant/foreman/node_modules/@theforeman/eslint-plugin-rules/lib/require-ouiaid.js
```
Then run:
```
cd /home/vagrant/foreman
npx eslint --no-eslintrc --no-inline-config \
  --plugin @theforeman/rules \
  --rule '@theforeman/rules/require-ouiaid: error' \
  --parser babel-eslint \
  ../foreman_rh_cloud/webpack/
```
That tests the default list. 
To test the additional option, create a minimal config file:
```
cat > /tmp/ouiaid-test.json << 'EOF'
{
  "parser": "babel-eslint",
  "plugins": ["@theforeman/rules"],
  "rules": {
    "@theforeman/rules/require-ouiaid": ["error", { "additional": ["MyExtraComponent"] }]
  }
}
EOF

cd /home/vagrant/foreman
npx eslint --no-eslintrc --no-inline-config \
  -c /tmp/ouiaid-test.json \
  ../foreman_rh_cloud/webpack/
```